### PR TITLE
Texture filter toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The Vulkan renderer comes with a set of its own additional console commands:
 | vk_validation         | Toggle validation layers.<br>0 - disabled (default in Release)<br> 1 - only errors and warnings<br>2 - full validation (default in Debug) |
 | vk_strings            | Print some basic Vulkan/GPU information.                                    |
 | vk_device             | Specifiy preferred Vulkan device index on systems with multiple GPUs.<br>-1 - prefer first DISCRETE_GPU (default)<br>0..n - use device #n (full list of devices is returned by vk_strings command) |
-| vk_msaa               | Toggle MSAA.<br>0 - off (default)<br>1 - MSAAx2<br>2 - MSAAx4<br>3 - MSAAx8 |
+| vk_msaa               | Toggle MSAA.<br>0 - off (default)<br>1 - MSAAx2<br>2 - MSAAx4<br>3 - MSAAx8<br>4 - MSAAx16 |
 | vk_mode               | Vulkan video mode (default: 11). Setting this to `-1` uses a custom screen resolution defined by `r_customwidth` (default: 1024) and `r_customheight` (default: 768) console variables. |
 | vk_flashblend         | Toggle the blending of lights onto the environment. (default: 0)            |
 | vk_polyblend          | Blend fullscreen effects: blood, powerups etc. (default: 1)                 |

--- a/README.md
+++ b/README.md
@@ -93,22 +93,24 @@ The Vulkan renderer comes with a set of its own additional console commands:
 | vk_skymip             | Toggle the usage of mipmap information for the sky graphics. (default: 0)   |
 | vk_finish             | Inserts vkDeviceWaitIdle() on render start (default: 0).<br>Don't use this, it's just for the sake of having a gl_finish equivalent. |
 | vk_point_particles    | Use POINT_LIST to render particles, textured triangles otherwise. (default: 1) |
-| vk_particle_size      | Rendered particle size. (default: 40)                   |
-| vk_particle_att_a     | Intensity of the particle A attribute. (default: 0.01)  |
-| vk_particle_att_b     | Intensity of the particle B attribute. (default: 0)     |
-| vk_particle_att_c     | Intensity of the particle C attribute. (default: 0.01)  |
-| vk_particle_min_size  | The minimum size for a rendered particle. (default: 2)  |
-| vk_particle_max_size  | The maximum size for a rendered particle. (default: 40) |
-| vk_lockpvs            | Lock current PVS table. (default: 0)                    |
-| vk_clear              | Clear the color buffer each frame. (default: 0)         |
-| vk_modulate           | Texture brightness modifier. (default: 1)               |
-| vk_shadows            | Draw experimental entity shadows. (default: 0)          |
-| vk_picmip             | Shrink factor for the textures. (default: 0)            |
-| vk_round_down         | Toggle the rounding of texture sizes. (default: 1)      |
-| vk_log                | Log frame validation data to file. (default: 0)         |
-| vk_dynamic            | Use dynamic lighting. (default: 1)                      |
-| vk_showtris           | Display mesh triangles. (default: 0)                    |
-| vk_lightmap           | Display lightmaps. (default: 0)                         |
+| vk_particle_size      | Rendered particle size. (default: 40)                    |
+| vk_particle_att_a     | Intensity of the particle A attribute. (default: 0.01)   |
+| vk_particle_att_b     | Intensity of the particle B attribute. (default: 0)      |
+| vk_particle_att_c     | Intensity of the particle C attribute. (default: 0.01)   |
+| vk_particle_min_size  | The minimum size for a rendered particle. (default: 2)   |
+| vk_particle_max_size  | The maximum size for a rendered particle. (default: 40)  |
+| vk_lockpvs            | Lock current PVS table. (default: 0)                     |
+| vk_clear              | Clear the color buffer each frame. (default: 0)          |
+| vk_modulate           | Texture brightness modifier. (default: 1)                |
+| vk_shadows            | Draw experimental entity shadows. (default: 0)           |
+| vk_picmip             | Shrink factor for the textures. (default: 0)             |
+| vk_round_down         | Toggle the rounding of texture sizes. (default: 1)       |
+| vk_log                | Log frame validation data to file. (default: 0)          |
+| vk_dynamic            | Use dynamic lighting. (default: 1)                       |
+| vk_showtris           | Display mesh triangles. (default: 0)                     |
+| vk_lightmap           | Display lightmaps. (default: 0)                          |
+| vk_aniso              | Toggle anisotropic filtering (default: 1)                |
+| vk_mip_nearfilter     | Use nearest neighbour filtering for mipmaps (default: 0) |
 | vk_texturemode        | Change current texture filtering.<br>VK_NEAREST - nearest filter, no mipmaps<br>VK_LINEAR - linear filter, no mipmaps<br>VK_MIPMAP_NEAREST - nearest filter with mipmaps<br>VK_MIPMAP_LINEAR - linear filter with mipmaps (default) |
 
 Acknowledgments

--- a/linux/vid_menu.c
+++ b/linux/vid_menu.c
@@ -292,6 +292,7 @@ void VID_MenuInit( void )
 		"x2",
 		"x4",
 		"x8",
+		"x16",
 		0
 	};
 	static const char *filter_modes[] =
@@ -430,19 +431,19 @@ void VID_MenuInit( void )
 		s_apply_action[i].generic.type = MTYPE_ACTION;
 		s_apply_action[i].generic.name = "apply changes";
 		s_apply_action[i].generic.x = 0;
-		s_apply_action[i].generic.y = 100 * vid_hudscale->value;
+		s_apply_action[i].generic.y = 110 * vid_hudscale->value;
 		s_apply_action[i].generic.callback = ApplyChanges;
 
 		s_defaults_action[i].generic.type = MTYPE_ACTION;
 		s_defaults_action[i].generic.name = "reset to defaults";
 		s_defaults_action[i].generic.x    = 0;
-		s_defaults_action[i].generic.y    = 110 * vid_hudscale->value;
+		s_defaults_action[i].generic.y    = 120 * vid_hudscale->value;
 		s_defaults_action[i].generic.callback = ResetDefaults;
 
 		s_cancel_action[i].generic.type = MTYPE_ACTION;
 		s_cancel_action[i].generic.name = "cancel";
 		s_cancel_action[i].generic.x    = 0;
-		s_cancel_action[i].generic.y    = 120 * vid_hudscale->value;
+		s_cancel_action[i].generic.y    = 130 * vid_hudscale->value;
 		s_cancel_action[i].generic.callback = CancelChanges;
 	}
 

--- a/linux/vid_menu.c
+++ b/linux/vid_menu.c
@@ -504,11 +504,11 @@ void VID_MenuInit( void )
 	s_texture_filter.generic.y = 90 * vid_hudscale->value;
 	s_texture_filter.itemnames = filter_modes;
 	s_texture_filter.curvalue = 0;
-	if(!Q_stricmp( vk_texturemode->string, "VK_LINEAR" ))
+	if ( !Q_stricmp( vk_texturemode->string, "VK_LINEAR" ) )
 		s_texture_filter.curvalue = 1;
-	if(!Q_stricmp( vk_texturemode->string, "VK_MIPMAP_NEAREST" ))
+	if ( !Q_stricmp( vk_texturemode->string, "VK_MIPMAP_NEAREST" ) )
 		s_texture_filter.curvalue = 2;
-	if(!Q_stricmp( vk_texturemode->string, "VK_MIPMAP_LINEAR" ))
+	if ( !Q_stricmp( vk_texturemode->string, "VK_MIPMAP_LINEAR" ) )
 		s_texture_filter.curvalue = 3;
 
 	Menu_AddItem( &s_software_menu, ( void * ) &s_ref_list[SOFTWARE_MENU] );
@@ -543,9 +543,9 @@ void VID_MenuInit( void )
 	Menu_AddItem( &s_opengl_menu, ( void * ) &s_apply_action[OPENGL_MENU] );
 	Menu_AddItem( &s_opengl_menu, ( void * ) &s_defaults_action[OPENGL_MENU] );
 	Menu_AddItem( &s_opengl_menu, ( void * ) &s_cancel_action[OPENGL_MENU] );
-	Menu_AddItem( &s_vulkan_menu, (void * ) &s_apply_action[VULKAN_MENU]);
-	Menu_AddItem( &s_vulkan_menu, (void * ) &s_defaults_action[VULKAN_MENU]);
-	Menu_AddItem( &s_vulkan_menu, (void * ) &s_cancel_action[VULKAN_MENU]);
+	Menu_AddItem( &s_vulkan_menu, (void * ) &s_apply_action[VULKAN_MENU] );
+	Menu_AddItem( &s_vulkan_menu, (void * ) &s_defaults_action[VULKAN_MENU] );
+	Menu_AddItem( &s_vulkan_menu, (void * ) &s_cancel_action[VULKAN_MENU] );
 
 	Menu_Center( &s_software_menu );
 	Menu_Center( &s_opengl_menu );

--- a/linux/vid_menu.c
+++ b/linux/vid_menu.c
@@ -40,6 +40,7 @@ static cvar_t *gl_driver;
 static cvar_t *gl_picmip;
 static cvar_t *gl_ext_palettedtexture;
 static cvar_t *vk_msaa;
+static cvar_t *vk_aniso;
 static cvar_t *vk_picmip;
 
 static cvar_t *sw_mode;
@@ -79,6 +80,7 @@ static menulist_s  		s_stipple_box;
 static menulist_s  		s_paletted_texture_box;
 static menulist_s  		s_windowed_mouse;
 static menulist_s		s_msaa_mode;
+static menulist_s		s_aniso_filter;
 static menuaction_s		s_apply_action[3];
 static menuaction_s		s_cancel_action[3];
 static menuaction_s		s_defaults_action[3];
@@ -167,6 +169,7 @@ static void ApplyChanges( void *unused )
 	Cvar_SetValue( "gl_mode", s_mode_list[OPENGL_MENU].curvalue == 0 ? -1 : s_mode_list[OPENGL_MENU].curvalue - 1 );
 	Cvar_SetValue( "vk_mode", s_mode_list[VULKAN_MENU].curvalue == 0 ? -1 : s_mode_list[VULKAN_MENU].curvalue - 1 );
 	Cvar_SetValue( "vk_msaa", s_msaa_mode.curvalue);
+	Cvar_SetValue( "vk_aniso", s_aniso_filter.curvalue);
 	Cvar_SetValue( "vk_picmip", 3 - s_tqvk_slider.curvalue );
 	Cvar_SetValue( "_windowed_mouse", s_windowed_mouse.curvalue);
 
@@ -274,6 +277,12 @@ void VID_MenuInit( void )
 		"x8",
 		0
 	};
+	static const char *on_off[] =
+	{
+		"off",
+		"on",
+		0
+	};
 	int i;
 
 	if ( !gl_driver )
@@ -288,6 +297,8 @@ void VID_MenuInit( void )
 		gl_ext_palettedtexture = Cvar_Get( "gl_ext_palettedtexture", "1", CVAR_ARCHIVE );
 	if ( !vk_msaa )
 		vk_msaa = Cvar_Get( "vk_msaa", "0", CVAR_ARCHIVE );
+	if ( !vk_aniso )
+		vk_aniso = Cvar_Get( "vk_aniso", "1", CVAR_ARCHIVE );
 	if ( !vk_picmip )
 		vk_picmip = Cvar_Get( "vk_picmip", "0", CVAR_ARCHIVE );
 	if ( !sw_stipplealpha )
@@ -452,6 +463,13 @@ void VID_MenuInit( void )
 	s_msaa_mode.itemnames = msaa_modes;
 	s_msaa_mode.curvalue = vk_msaa->value;
 
+	s_aniso_filter.generic.type = MTYPE_SPINCONTROL;
+	s_aniso_filter.generic.name = "anisotropic filtering";
+	s_aniso_filter.generic.x = 0;
+	s_aniso_filter.generic.y = 80 * vid_hudscale->value;
+	s_aniso_filter.itemnames = on_off;
+	s_aniso_filter.curvalue = vk_aniso->value > 0 ? 1 : 0;
+
 	Menu_AddItem( &s_software_menu, ( void * ) &s_ref_list[SOFTWARE_MENU] );
 	Menu_AddItem( &s_software_menu, ( void * ) &s_mode_list[SOFTWARE_MENU] );
 	Menu_AddItem( &s_software_menu, ( void * ) &s_screensize_slider[SOFTWARE_MENU] );
@@ -475,6 +493,7 @@ void VID_MenuInit( void )
 	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_fs_box[VULKAN_MENU]);
 	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_tqvk_slider);
 	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_msaa_mode);
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_aniso_filter);
 
 	Menu_AddItem( &s_software_menu, ( void * ) &s_apply_action[SOFTWARE_MENU] );
 	Menu_AddItem( &s_software_menu, ( void * ) &s_defaults_action[SOFTWARE_MENU] );

--- a/linux/vid_menu.c
+++ b/linux/vid_menu.c
@@ -41,6 +41,7 @@ static cvar_t *gl_picmip;
 static cvar_t *gl_ext_palettedtexture;
 static cvar_t *vk_msaa;
 static cvar_t *vk_aniso;
+static cvar_t *vk_texturemode;
 static cvar_t *vk_picmip;
 
 static cvar_t *sw_mode;
@@ -81,6 +82,7 @@ static menulist_s  		s_paletted_texture_box;
 static menulist_s  		s_windowed_mouse;
 static menulist_s		s_msaa_mode;
 static menulist_s		s_aniso_filter;
+static menulist_s		s_texture_filter;
 static menuaction_s		s_apply_action[3];
 static menuaction_s		s_cancel_action[3];
 static menuaction_s		s_defaults_action[3];
@@ -172,6 +174,21 @@ static void ApplyChanges( void *unused )
 	Cvar_SetValue( "vk_aniso", s_aniso_filter.curvalue);
 	Cvar_SetValue( "vk_picmip", 3 - s_tqvk_slider.curvalue );
 	Cvar_SetValue( "_windowed_mouse", s_windowed_mouse.curvalue);
+
+	switch ( s_texture_filter.curvalue )
+	{
+	case 0:
+		Cvar_Set( "vk_texturemode", "VK_NEAREST" );
+		break;
+	case 1:
+		Cvar_Set( "vk_texturemode", "VK_LINEAR" );
+		break;
+	case 2:
+		Cvar_Set( "vk_texturemode", "VK_MIPMAP_NEAREST" );
+		break;
+	default:
+		Cvar_Set( "vk_texturemode", "VK_MIPMAP_LINEAR" );
+	}
 
 	switch ( s_ref_list[s_current_menu_index].curvalue )
 	{
@@ -277,6 +294,14 @@ void VID_MenuInit( void )
 		"x8",
 		0
 	};
+	static const char *filter_modes[] =
+	{
+		"nearest",
+		"linear",
+		"mipmap nearest",
+		"mipmap linear",
+		0
+	};
 	static const char *on_off[] =
 	{
 		"off",
@@ -299,6 +324,8 @@ void VID_MenuInit( void )
 		vk_msaa = Cvar_Get( "vk_msaa", "0", CVAR_ARCHIVE );
 	if ( !vk_aniso )
 		vk_aniso = Cvar_Get( "vk_aniso", "1", CVAR_ARCHIVE );
+	if ( !vk_texturemode )
+		vk_texturemode = Cvar_Get( "vk_texturemode", "VK_MIPMAP_LINEAR", CVAR_ARCHIVE );
 	if ( !vk_picmip )
 		vk_picmip = Cvar_Get( "vk_picmip", "0", CVAR_ARCHIVE );
 	if ( !sw_stipplealpha )
@@ -470,6 +497,19 @@ void VID_MenuInit( void )
 	s_aniso_filter.itemnames = on_off;
 	s_aniso_filter.curvalue = vk_aniso->value > 0 ? 1 : 0;
 
+	s_texture_filter.generic.type = MTYPE_SPINCONTROL;
+	s_texture_filter.generic.name = "texture filtering";
+	s_texture_filter.generic.x = 0;
+	s_texture_filter.generic.y = 90 * vid_hudscale->value;
+	s_texture_filter.itemnames = filter_modes;
+	s_texture_filter.curvalue = 0;
+	if(!Q_stricmp( vk_texturemode->string, "VK_LINEAR" ))
+		s_texture_filter.curvalue = 1;
+	if(!Q_stricmp( vk_texturemode->string, "VK_MIPMAP_NEAREST" ))
+		s_texture_filter.curvalue = 2;
+	if(!Q_stricmp( vk_texturemode->string, "VK_MIPMAP_LINEAR" ))
+		s_texture_filter.curvalue = 3;
+
 	Menu_AddItem( &s_software_menu, ( void * ) &s_ref_list[SOFTWARE_MENU] );
 	Menu_AddItem( &s_software_menu, ( void * ) &s_mode_list[SOFTWARE_MENU] );
 	Menu_AddItem( &s_software_menu, ( void * ) &s_screensize_slider[SOFTWARE_MENU] );
@@ -486,14 +526,15 @@ void VID_MenuInit( void )
 	Menu_AddItem( &s_opengl_menu, ( void * ) &s_tq_slider );
 	Menu_AddItem( &s_opengl_menu, ( void * ) &s_paletted_texture_box );
 
-	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_ref_list[VULKAN_MENU]);
-	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_mode_list[VULKAN_MENU]);
-	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_screensize_slider[VULKAN_MENU]);
-	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_brightness_slider[VULKAN_MENU]);
-	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_fs_box[VULKAN_MENU]);
-	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_tqvk_slider);
-	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_msaa_mode);
-	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_aniso_filter);
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_ref_list[VULKAN_MENU] );
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_mode_list[VULKAN_MENU] );
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_screensize_slider[VULKAN_MENU] );
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_brightness_slider[VULKAN_MENU] );
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_fs_box[VULKAN_MENU] );
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_tqvk_slider );
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_msaa_mode );
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_aniso_filter );
+	Menu_AddItem( &s_vulkan_menu, ( void * ) &s_texture_filter );
 
 	Menu_AddItem( &s_software_menu, ( void * ) &s_apply_action[SOFTWARE_MENU] );
 	Menu_AddItem( &s_software_menu, ( void * ) &s_defaults_action[SOFTWARE_MENU] );

--- a/ref_vk/qvk.h
+++ b/ref_vk/qvk.h
@@ -59,14 +59,19 @@ typedef struct
 	int imageCount;
 } qvkswapchain_t;
 
-// texture options
-typedef struct
+// available sampler types
+typedef enum
 {
-	VkFilter  minFilter;
-	VkFilter  magFilter;
-	VkFilter  mipmapFilter;
-	VkSamplerMipmapMode mipmapMode;
-} qvktextureopts_t;
+	S_NEAREST = 0,
+	S_LINEAR = 1,
+	S_MIPMAP_NEAREST = 2,
+	S_MIPMAP_LINEAR = 3,
+	S_ANISO_NEAREST = 4,
+	S_ANISO_LINEAR = 5,
+	S_ANISO_MIPMAP_NEAREST = 6,
+	S_ANISO_MIPMAP_LINEAR = 7,
+	S_SAMPLER_CNT = 8
+} qvksampler_t;
 
 // texture object
 typedef struct 
@@ -75,17 +80,12 @@ typedef struct
 	VmaAllocation allocation;
 	VmaAllocationCreateFlags vmaFlags;
 	VkImageView   imageView;
-	VkSampler sampler;
 	VkSharingMode sharingMode;
 	VkSampleCountFlagBits sampleCount;
 	VkFormat  format;
 	VkDescriptorSet descriptorSet;
 	// mipmap settings
 	uint32_t mipLevels;
-	float mipLodBias;
-	float mipMinLod;
-	VkSamplerMipmapMode mipmapMode;
-	VkFilter mipmapFilter;
 } qvktexture_t;
 
 #define QVVKTEXTURE_INIT     { \
@@ -93,16 +93,11 @@ typedef struct
 	.allocation = VK_NULL_HANDLE, \
 	.vmaFlags = 0, \
 	.imageView = VK_NULL_HANDLE, \
-	.sampler = VK_NULL_HANDLE, \
 	.sharingMode = VK_SHARING_MODE_MAX_ENUM, \
 	.sampleCount = VK_SAMPLE_COUNT_1_BIT, \
 	.format = VK_FORMAT_R8G8B8A8_UNORM, \
 	.descriptorSet = VK_NULL_HANDLE, \
 	.mipLevels = 1, \
-	.mipLodBias = 0.f, \
-	.mipMinLod = 0.f, \
-	.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR, \
-	.mipmapFilter = VK_FILTER_LINEAR \
 }
 
 #define QVVKTEXTURE_CLEAR(i)     { \
@@ -110,15 +105,10 @@ typedef struct
 	(i).allocation = VK_NULL_HANDLE; \
 	(i).vmaFlags = 0; \
 	(i).imageView = VK_NULL_HANDLE; \
-	(i).sampler = VK_NULL_HANDLE; \
 	(i).sharingMode = VK_SHARING_MODE_MAX_ENUM; \
 	(i).sampleCount = VK_SAMPLE_COUNT_1_BIT; \
 	(i).format = VK_FORMAT_R8G8B8A8_UNORM; \
 	(i).mipLevels = 1; \
-	(i).mipLodBias = 0.f; \
-	(i).mipMinLod = 0.f; \
-	(i).mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR; \
-	(i).mipmapFilter = VK_FILTER_LINEAR; \
 }
 
 // Vulkan renderpass
@@ -279,8 +269,9 @@ VkResult	QVk_CreateImageView(const VkImage *image, VkImageAspectFlags aspectFlag
 VkResult	QVk_CreateImage(uint32_t width, uint32_t height, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VmaMemoryUsage memUsage, qvktexture_t *texture);
 void		QVk_CreateDepthBuffer(VkSampleCountFlagBits sampleCount, qvktexture_t *depthBuffer);
 void		QVk_CreateColorBuffer(VkSampleCountFlagBits sampleCount, qvktexture_t *colorBuffer);
-void		QVk_CreateTexture(qvktexture_t *texture, const unsigned char *data, uint32_t width, uint32_t height, qvktextureopts_t *texOpts);
-void		QVk_UpdateTexture(qvktexture_t *texture, const unsigned char *data, uint32_t offset_x, uint32_t offset_y, uint32_t width, uint32_t height);
+void		QVk_CreateTexture(qvktexture_t *texture, const unsigned char *data, uint32_t width, uint32_t height, qvksampler_t samplerType);
+void		QVk_UpdateTextureData(qvktexture_t *texture, const unsigned char *data, uint32_t offset_x, uint32_t offset_y, uint32_t width, uint32_t height);
+VkSampler	QVk_UpdateTextureSampler(qvktexture_t *texture, qvksampler_t samplerType);
 void		QVk_ReleaseTexture(qvktexture_t *texture);
 void		QVk_ReadPixels(uint8_t *dstBuffer, uint32_t width, uint32_t height);
 VkResult	QVk_BeginCommand(const VkCommandBuffer *commandBuffer);

--- a/ref_vk/vk_common.c
+++ b/ref_vk/vk_common.c
@@ -212,6 +212,8 @@ VkDescriptorSetLayout vk_uboDescSetLayout;
 VkDescriptorSetLayout vk_samplerDescSetLayout;
 VkDescriptorSetLayout vk_samplerLightmapDescSetLayout;
 
+extern cvar_t *vk_msaa;
+
 VkFormat QVk_FindDepthFormat()
 {
 	VkFormat depthFormats[] = {
@@ -237,8 +239,6 @@ VkFormat QVk_FindDepthFormat()
 // internal helper
 static VkSampleCountFlagBits GetSampleCount()
 {
-	extern cvar_t *vk_msaa;
-
 	static VkSampleCountFlagBits msaaModes[] = {
 		VK_SAMPLE_COUNT_1_BIT,
 		VK_SAMPLE_COUNT_2_BIT,
@@ -1117,7 +1117,6 @@ qboolean QVk_Init()
 		ri.Cvar_Set("vk_msaa", "0");
 		msaaMode = VK_SAMPLE_COUNT_1_BIT;
 		// avoid secondary video reload
-		extern cvar_t *vk_msaa;
 		vk_msaa->modified = false;
 	}
 

--- a/ref_vk/vk_common.c
+++ b/ref_vk/vk_common.c
@@ -243,7 +243,8 @@ static VkSampleCountFlagBits GetSampleCount()
 		VK_SAMPLE_COUNT_1_BIT,
 		VK_SAMPLE_COUNT_2_BIT,
 		VK_SAMPLE_COUNT_4_BIT,
-		VK_SAMPLE_COUNT_8_BIT
+		VK_SAMPLE_COUNT_8_BIT,
+		VK_SAMPLE_COUNT_16_BIT
 	};
 
 	return msaaModes[(int)vk_msaa->value];
@@ -1114,7 +1115,10 @@ qboolean QVk_Init()
 	{
 		ri.Con_Printf(PRINT_ALL, "MSAAx%d mode not supported, aborting...\n", msaaMode);
 		ri.Cvar_Set("vk_msaa", "0");
-		return false;
+		msaaMode = VK_SAMPLE_COUNT_1_BIT;
+		// avoid secondary video reload
+		extern cvar_t *vk_msaa;
+		vk_msaa->modified = false;
 	}
 
 	if (msaaMode != VK_SAMPLE_COUNT_1_BIT)

--- a/ref_vk/vk_draw.c
+++ b/ref_vk/vk_draw.c
@@ -33,11 +33,8 @@ Draw_InitLocal
 void Draw_InitLocal (void)
 {
 	// load console characters (don't bilerp characters)
-	qvktextureopts_t texOpts = {
-		.minFilter = VK_FILTER_NEAREST,
-		.magFilter = VK_FILTER_NEAREST
-	};
-	draw_chars = Vk_FindImage("pics/conchars.pcx", it_pic, &texOpts);
+	qvksampler_t samplerType = S_NEAREST;
+	draw_chars = Vk_FindImage("pics/conchars.pcx", it_pic, &samplerType);
 }
 
 
@@ -287,12 +284,12 @@ void Draw_StretchRaw (int x, int y, int w, int h, int cols, int rows, byte *data
 
 	if (vk_rawTexture.image != VK_NULL_HANDLE)
 	{
-		QVk_UpdateTexture(&vk_rawTexture, (unsigned char*)&image32, 0, 0, 256, 256);
+		QVk_UpdateTextureData(&vk_rawTexture, (unsigned char*)&image32, 0, 0, 256, 256);
 	}
 	else
 	{
 		QVVKTEXTURE_CLEAR(vk_rawTexture);
-		QVk_CreateTexture(&vk_rawTexture, (unsigned char*)&image32, 256, 256, &vk_global_tex_opts);
+		QVk_CreateTexture(&vk_rawTexture, (unsigned char*)&image32, 256, 256, vk_current_sampler);
 	}
 
 	float imgTransform[] = { (float)x / vid.width, (float)y / vid.height,

--- a/ref_vk/vk_image.c
+++ b/ref_vk/vk_image.c
@@ -702,6 +702,9 @@ void Vk_TextureMode( char *string )
 		if (vk_state.lightmap_textures[j].image != VK_NULL_HANDLE)
 			QVk_UpdateTextureSampler(&vk_state.lightmap_textures[j], i);
 	}
+
+	if (vk_rawTexture.image != VK_NULL_HANDLE)
+		QVk_UpdateTextureSampler(&vk_rawTexture, i);
 }
 
 /*

--- a/ref_vk/vk_local.h
+++ b/ref_vk/vk_local.h
@@ -199,6 +199,7 @@ extern	cvar_t	*vk_dynamic;
 extern	cvar_t	*vk_showtris;
 extern	cvar_t	*vk_lightmap;
 extern	cvar_t	*vk_texturemode;
+extern	cvar_t	*vk_aniso;
 extern	cvar_t	*vk_device_idx;
 
 extern	cvar_t	*vid_fullscreen;
@@ -221,7 +222,7 @@ extern	model_t	*r_worldmodel;
 extern	unsigned	d_8to24table[256];
 
 extern	int		registration_sequence;
-extern	qvktextureopts_t vk_global_tex_opts;
+extern	qvksampler_t vk_current_sampler;
 
 qboolean R_Init( void *hinstance, void *hWnd );
 void	 R_Shutdown( void );
@@ -271,9 +272,9 @@ void Vk_ResampleTexture (unsigned *in, int inwidth, int inheight, unsigned *out,
 struct image_s *R_RegisterSkin (char *name);
 
 void LoadPCX (char *filename, byte **pic, byte **palette, int *width, int *height);
-image_t *Vk_LoadPic (char *name, byte *pic, int width, int height, imagetype_t type, int bits, qvktextureopts_t *texOpts);
-image_t	*Vk_FindImage (char *name, imagetype_t type, qvktextureopts_t *texOpts);
-qboolean Vk_TextureMode( char *string );
+image_t *Vk_LoadPic (char *name, byte *pic, int width, int height, imagetype_t type, int bits, qvksampler_t *samplerType);
+image_t	*Vk_FindImage (char *name, imagetype_t type, qvksampler_t *samplerType);
+void	Vk_TextureMode( char *string );
 void	Vk_ImageList_f (void);
 
 void	Vk_InitImages (void);

--- a/ref_vk/vk_rmain.c
+++ b/ref_vk/vk_rmain.c
@@ -112,6 +112,8 @@ cvar_t	*vk_msaa;
 cvar_t	*vk_showtris;
 cvar_t	*vk_lightmap;
 cvar_t	*vk_texturemode;
+cvar_t	*vk_aniso;
+cvar_t	*vk_mip_nearfilter;
 cvar_t	*vk_device_idx;
 
 cvar_t	*vid_fullscreen;
@@ -1027,6 +1029,8 @@ void R_Register( void )
 	vk_showtris = ri.Cvar_Get("vk_showtris", "0", 0);
 	vk_lightmap = ri.Cvar_Get("vk_lightmap", "0", 0);
 	vk_texturemode = ri.Cvar_Get("vk_texturemode", "VK_MIPMAP_LINEAR", CVAR_ARCHIVE);
+	vk_aniso = ri.Cvar_Get("vk_aniso", "1", CVAR_ARCHIVE);
+	vk_mip_nearfilter = ri.Cvar_Get("vk_mip_nearfilter", "0", CVAR_ARCHIVE);
 	vk_device_idx = ri.Cvar_Get("vk_device", "-1", CVAR_ARCHIVE);
 	if (vk_msaa->value < 0)
 		ri.Cvar_Set("vk_msaa", "0");
@@ -1059,13 +1063,10 @@ qboolean R_SetMode (void)
 	vk_msaa->modified = false;
 	vk_clear->modified = false;
 	vk_validation->modified = false;
+	vk_mip_nearfilter->modified = false;
 	vk_device_idx->modified = false;
-
-	if (vk_texturemode->modified)
-	{
-		Vk_TextureMode(vk_texturemode->string);
-		vk_texturemode->modified = false;
-	}
+	// refresh texture samplers
+	vk_texturemode->modified = true;
 
 	if ((err = Vkimp_SetMode((int*)&vid.width, (int*)&vid.height, vk_mode->value, fullscreen)) == rserr_ok)
 	{
@@ -1181,16 +1182,13 @@ void R_BeginFrame( float camera_separation )
 	** change modes if necessary
 	*/
 	if (vk_mode->modified || vid_fullscreen->modified || vk_msaa->modified || vk_clear->modified || 
-		vk_validation->modified || vk_texturemode->modified || vk_device_idx->modified)
+		vk_validation->modified || vk_texturemode->modified || vk_aniso->modified || vk_mip_nearfilter->modified || vk_device_idx->modified)
 	{
-		if (vk_texturemode->modified)
+		if (vk_texturemode->modified || vk_aniso->modified)
 		{
-			if (Vk_TextureMode(vk_texturemode->string))
-			{
-				cvar_t	*ref = ri.Cvar_Get("vid_ref", "vk", 0);
-				ref->modified = true;
-			}
-
+			Vk_TextureMode(vk_texturemode->string);
+			vk_texturemode->modified = false;
+			vk_aniso->modified = false;
 		}
 		else
 		{

--- a/ref_vk/vk_rmain.c
+++ b/ref_vk/vk_rmain.c
@@ -1032,6 +1032,7 @@ void R_Register( void )
 	vk_aniso = ri.Cvar_Get("vk_aniso", "1", CVAR_ARCHIVE);
 	vk_mip_nearfilter = ri.Cvar_Get("vk_mip_nearfilter", "0", CVAR_ARCHIVE);
 	vk_device_idx = ri.Cvar_Get("vk_device", "-1", CVAR_ARCHIVE);
+	// clamp vk_msaa to accepted range so that video menu doesn't crash on us
 	if (vk_msaa->value < 0)
 		ri.Cvar_Set("vk_msaa", "0");
 	else if (vk_msaa->value > 4)

--- a/ref_vk/vk_rmain.c
+++ b/ref_vk/vk_rmain.c
@@ -1034,8 +1034,8 @@ void R_Register( void )
 	vk_device_idx = ri.Cvar_Get("vk_device", "-1", CVAR_ARCHIVE);
 	if (vk_msaa->value < 0)
 		ri.Cvar_Set("vk_msaa", "0");
-	else if (vk_msaa->value > 3)
-		ri.Cvar_Set("vk_msaa", "3");
+	else if (vk_msaa->value > 4)
+		ri.Cvar_Set("vk_msaa", "4");
 
 	vid_fullscreen = ri.Cvar_Get("vid_fullscreen", "0", CVAR_ARCHIVE);
 	vid_gamma = ri.Cvar_Get("vid_gamma", "1.0", CVAR_ARCHIVE);

--- a/ref_vk/vk_rsurf.c
+++ b/ref_vk/vk_rsurf.c
@@ -331,7 +331,7 @@ void R_RenderBrushPoly (msurface_t *fa, float *modelMatrix, float alpha)
 			R_BuildLightMap(fa, (void *)temp, smax * 4);
 			R_SetCacheState(fa);
 
-			QVk_UpdateTexture(&vk_state.lightmap_textures[fa->lightmaptexturenum], (unsigned char*)temp, fa->light_s, fa->light_t, smax, tmax);
+			QVk_UpdateTextureData(&vk_state.lightmap_textures[fa->lightmaptexturenum], (unsigned char*)temp, fa->light_s, fa->light_t, smax, tmax);
 			
 			fa->lightmapchain = vk_lms.lightmap_surfaces[fa->lightmaptexturenum];
 			vk_lms.lightmap_surfaces[fa->lightmaptexturenum] = fa;
@@ -509,7 +509,7 @@ static void Vk_RenderLightmappedPoly( msurface_t *surf, float *modelMatrix, floa
 			R_SetCacheState(surf);
 
 			lmtex = surf->lightmaptexturenum;
-			QVk_UpdateTexture(&vk_state.lightmap_textures[surf->lightmaptexturenum], (unsigned char *)temp, surf->light_s, surf->light_t, smax, tmax);
+			QVk_UpdateTextureData(&vk_state.lightmap_textures[surf->lightmaptexturenum], (unsigned char *)temp, surf->light_s, surf->light_t, smax, tmax);
 		}
 		else
 		{
@@ -519,7 +519,7 @@ static void Vk_RenderLightmappedPoly( msurface_t *surf, float *modelMatrix, floa
 			R_BuildLightMap(surf, (void *)temp, smax * 4);
 
 			lmtex = surf->lightmaptexturenum + DYNLIGHTMAP_OFFSET;
-			QVk_UpdateTexture(&vk_state.lightmap_textures[lmtex], (unsigned char *)temp, surf->light_s, surf->light_t, smax, tmax);
+			QVk_UpdateTextureData(&vk_state.lightmap_textures[lmtex], (unsigned char *)temp, surf->light_s, surf->light_t, smax, tmax);
 		}
 
 		c_brush_polys++;
@@ -1073,16 +1073,16 @@ static void LM_UploadBlock( qboolean dynamic )
 			if ( vk_lms.allocated[i] > height )
 				height = vk_lms.allocated[i];
 		}
-		QVk_UpdateTexture(&vk_state.lightmap_textures[texture], vk_lms.lightmap_buffer, 0, 0, BLOCK_WIDTH, height);
+		QVk_UpdateTextureData(&vk_state.lightmap_textures[texture], vk_lms.lightmap_buffer, 0, 0, BLOCK_WIDTH, height);
 	}
 	else
 	{
 		if (vk_state.lightmap_textures[texture].image != VK_NULL_HANDLE)
-			QVk_UpdateTexture(&vk_state.lightmap_textures[texture], vk_lms.lightmap_buffer, 0, 0, BLOCK_WIDTH, BLOCK_HEIGHT);
+			QVk_UpdateTextureData(&vk_state.lightmap_textures[texture], vk_lms.lightmap_buffer, 0, 0, BLOCK_WIDTH, BLOCK_HEIGHT);
 		else
 		{
 			QVVKTEXTURE_CLEAR(vk_state.lightmap_textures[texture]);
-			QVk_CreateTexture(&vk_state.lightmap_textures[texture], vk_lms.lightmap_buffer, BLOCK_WIDTH, BLOCK_HEIGHT, &vk_global_tex_opts);
+			QVk_CreateTexture(&vk_state.lightmap_textures[texture], vk_lms.lightmap_buffer, BLOCK_WIDTH, BLOCK_HEIGHT, vk_current_sampler);
 		}
 		if ( ++vk_lms.current_lightmap_texture == MAX_LIGHTMAPS )
 			ri.Sys_Error( ERR_DROP, "LM_UploadBlock() - MAX_LIGHTMAPS exceeded\n" );
@@ -1275,7 +1275,7 @@ void Vk_BeginBuildingLightmaps (model_t *m)
 		for (i = DYNLIGHTMAP_OFFSET; i < MAX_LIGHTMAPS*2; i++)
 		{
 			QVVKTEXTURE_CLEAR(vk_state.lightmap_textures[i]);
-			QVk_CreateTexture(&vk_state.lightmap_textures[i], (unsigned char*)dummy, BLOCK_WIDTH, BLOCK_HEIGHT, &vk_global_tex_opts);
+			QVk_CreateTexture(&vk_state.lightmap_textures[i], (unsigned char*)dummy, BLOCK_WIDTH, BLOCK_HEIGHT, vk_current_sampler);
 		}
 	}
 }

--- a/win32/vid_menu.c
+++ b/win32/vid_menu.c
@@ -522,11 +522,11 @@ void VID_MenuInit( void )
 	s_texture_filter.generic.y = 100 * vid_hudscale->value;
 	s_texture_filter.itemnames = filter_modes;
 	s_texture_filter.curvalue = 0;
-	if (!Q_stricmp(vk_texturemode->string, "VK_LINEAR"))
+	if ( !Q_stricmp( vk_texturemode->string, "VK_LINEAR" ) )
 		s_texture_filter.curvalue = 1;
-	if (!Q_stricmp(vk_texturemode->string, "VK_MIPMAP_NEAREST"))
+	if ( !Q_stricmp( vk_texturemode->string, "VK_MIPMAP_NEAREST" ) )
 		s_texture_filter.curvalue = 2;
-	if (!Q_stricmp(vk_texturemode->string, "VK_MIPMAP_LINEAR"))
+	if ( !Q_stricmp( vk_texturemode->string, "VK_MIPMAP_LINEAR" ) )
 		s_texture_filter.curvalue = 3;
 
 	Menu_AddItem( &s_software_menu, ( void * ) &s_ref_list[SOFTWARE_MENU] );


### PR DESCRIPTION
Added a toggle in video menu to enable/disable anisotropic filtering (also via `vk_aniso` console command) and the value of `vk_texturemode`. Added MSAAx16 mode to the list of supported multisampling modes. Samplers are no longer bound to each texture but are shared between objects for a smaller memory footprint.