### PR TITLE
Add makefile and instructions to just Command Line Tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ sudo apt install mesa-vulkan-drivers
 
 ## MacOS
 - download and extract the [Vulkan SDK](https://vulkan.lunarg.com/)
-- install XCode 10.1 (or later) and add the `VULKAN_SDK` environment variable to Locations/Custom Paths - make it point to the downloaded SDK
+- can be built with XCode or with just the Command Line Tools
+- if using XCode, install XCode 10.1 (or later) and add the `VULKAN_SDK` environment variable to Locations/Custom Paths - make it point to the downloaded SDK
 - open `macos/vkQuake2.xcworkspace` - it should build without any additional steps
 - alternatively, you can compile the game from the command line - modify your `.bash_profile` and add the following entries (replace SDK version and location with the ones corresponding to your system):
 ```
@@ -65,7 +66,8 @@ export VULKAN_SDK=/home/user/VulkanSDK/1.1.92.1
 export VK_ICD_FILENAMES=$VULKAN_SDK/macOS/etc/vulkan/icd.d/MoltenVK_icd.json
 export VK_LAYER_PATH=$VULKAN_SDK/macOS/etc/vulkan/explicit_layer.d
 ```
-- enter the `macos` directory and run `make release` or `make debug` depending on which variant you want to build - output binaries will be placed in `macos/vkQuake2` subdirectory
+- enter the `macos` directory and run `make release-xcode` or `make debug-xcode` depending on which variant you want to build - output binaries will be placed in `macos/vkQuake2` subdirectory
+- if using just Command Line Tools with `xcode-select --install` then enter the `macos` directory and run `make release` or `make debug` similar to XCode method above
 
 This project uses the Vulkan loader bundled with the SDK, rather than directly linking against `MoltenVK.framework`. This is done so that validation layers are available for debugging. Builds have been tested using MacOS 10.14.2.
 

--- a/macos/Makefile
+++ b/macos/Makefile
@@ -1,11 +1,1351 @@
-# vkQuake2 for MacOS
+#
+# Quake2 Makefile for Linux 2.0
+# 64-bit version
+#
+# Nov '97 by Zoid <zoid@idsoftware.com>
+# Jan '19 by Krzysztof Kondrak <krzysztof.kondrak@gmail.com>
+#
+# ELF only
+#
 
-debug:
+VERSION=3.21
+VERSION_FN=$(VERSION)$(GLIBC)
+
+ARCH=x64
+NOARCH=noarch
+
+MOUNT_DIR=..
+VWEP_DIR=/grog/Projects/Quake2/vwep
+QUAKE2_DIR=/grog/Projects/Quake2Master
+
+BUILD_DEBUG_DIR=debug$(ARCH)$(GLIBC)
+BUILD_RELEASE_DIR=release$(ARCH)$(GLIBC)
+CLIENT_DIR=$(MOUNT_DIR)/client
+SERVER_DIR=$(MOUNT_DIR)/server
+REF_VK_DIR=$(MOUNT_DIR)/ref_vk
+COMMON_DIR=$(MOUNT_DIR)/qcommon
+LINUX_DIR=$(MOUNT_DIR)/linux
+GAME_DIR=$(MOUNT_DIR)/game
+NULL_DIR=$(MOUNT_DIR)/null
+MACOS_DIR=$(MOUNT_DIR)/macos
+CTF_DIR=$(MOUNT_DIR)/ctf
+XATRIX_DIR=$(MOUNT_DIR)/xatrix
+ROGUE_DIR=$(MOUNT_DIR)/rogue
+
+CC=gcc
+BASE_CFLAGS=-Dstricmp=strcasecmp -D_GNU_SOURCE -Wno-unused-result
+
+RELEASE_CFLAGS=$(BASE_CFLAGS) -DNDEBUG -O3 -ffast-math -funroll-loops \
+	-fomit-frame-pointer
+
+DEBUG_CFLAGS=$(BASE_CFLAGS) -g -D_DEBUG
+LDFLAGS=-ldl -lm -framework CoreAudio
+SVGALDFLAGS=-lvga -lm
+XLDFLAGS=
+XCFLAGS=
+
+VKLDFLAGS=-L$(VULKAN_SDK)/lib -Xlinker -rpath -Xlinker $(VULKAN_SDK)/lib -lm -lvulkan -framework CoreGraphics -lstdc++ -framework QuartzCore -framework Cocoa -framework Carbon
+VKCFLAGS=-I$(VULKAN_SDK)/include
+
+SHLIBEXT=dylib
+
+SHLIBCFLAGS=-fPIC -std=c99
+SHLIBCPPFLAGS=-fPIC -std=c++11
+SHLIBLDFLAGS=-shared
+
+DO_CC=$(CC) $(CFLAGS) -o $@ -c $<
+DO_DEBUG_CC=$(CC) $(DEBUG_CFLAGS) -o $@ -c $<
+DO_DED_CC=$(CC) $(CFLAGS) -DDEDICATED_ONLY -o $@ -c $<
+DO_DED_DEBUG_CC=$(CC) $(DEBUG_CFLAGS) -DDEDICATED_ONLY -o $@ -c $<
+DO_O_CC=$(CC) $(CFLAGS) -O -o $@ -c $<
+DO_SHLIB_CC=$(CC) $(CFLAGS) $(SHLIBCFLAGS) -o $@ -c $<
+DO_SHLIB_O_CC=$(CC) $(CFLAGS) -O $(SHLIBCFLAGS) -o $@ -c $<
+DO_SHLIB_DEBUG_CC=$(CC) $(DEBUG_CFLAGS) $(SHLIBCFLAGS) -o $@ -c $<
+DO_VK_SHLIB_CC=$(CC) $(CFLAGS) $(SHLIBCFLAGS) $(VKCFLAGS) -o $@ -c $<
+DO_VK_SHLIB_CPP=$(CC) $(CFLAGS) $(SHLIBCPPFLAGS) $(VKCFLAGS) -o $@ -c $<
+DO_VK_SHLIB_O_CC=$(CC) $(CFLAGS) -O $(SHLIBCFLAGS) $(VKCFLAGS) -o $@ -c $<
+DO_AS=$(CC) $(CFLAGS) -DELF -x assembler-with-cpp -o $@ -c $<
+DO_SHLIB_AS=$(CC) $(CFLAGS) $(SHLIBCFLAGS) -DELF -x assembler-with-cpp -o $@ -c $<
+
+#############################################################################
+# SETUP AND BUILD
+#############################################################################
+
+TARGETS=$(BUILDDIR)/quake2 \
+	$(BUILDDIR)/baseq2/game$(ARCH).$(SHLIBEXT) \
+	$(BUILDDIR)/ctf/game$(ARCH).$(SHLIBEXT) \
+	$(BUILDDIR)/ref_vk.$(SHLIBEXT) \
+	$(BUILDDIR)/xatrix/game$(ARCH).$(SHLIBEXT) \
+	$(BUILDDIR)/rogue/game$(ARCH).$(SHLIBEXT)
+
+build_debug:
+	@-mkdir -p $(BUILD_DEBUG_DIR) \
+		$(BUILD_DEBUG_DIR)/baseq2 \
+		$(BUILD_DEBUG_DIR)/client \
+		$(BUILD_DEBUG_DIR)/ded \
+		$(BUILD_DEBUG_DIR)/ref_vk \
+		$(BUILD_DEBUG_DIR)/game \
+		$(BUILD_DEBUG_DIR)/ctf \
+		$(BUILD_DEBUG_DIR)/xatrix \
+		$(BUILD_DEBUG_DIR)/rogue
+	$(MAKE) targets BUILDDIR=$(BUILD_DEBUG_DIR) CFLAGS="$(DEBUG_CFLAGS)"
+
+build_release:
+	@-mkdir -p $(BUILD_RELEASE_DIR) \
+		$(BUILD_RELEASE_DIR)/baseq2 \
+		$(BUILD_RELEASE_DIR)/client \
+		$(BUILD_RELEASE_DIR)/ded \
+		$(BUILD_RELEASE_DIR)/ref_vk \
+		$(BUILD_RELEASE_DIR)/game \
+		$(BUILD_RELEASE_DIR)/ctf \
+		$(BUILD_RELEASE_DIR)/xatrix \
+		$(BUILD_RELEASE_DIR)/rogue
+	$(MAKE) targets BUILDDIR=$(BUILD_RELEASE_DIR) CFLAGS="$(RELEASE_CFLAGS)"
+
+all: build_debug build_release
+debug: build_debug
+release: build_release
+
+targets: $(TARGETS)
+
+#############################################################################
+# CLIENT/SERVER
+#############################################################################
+
+QUAKE2_OBJS = \
+	$(BUILDDIR)/client/cl_cin.o \
+	$(BUILDDIR)/client/cl_ents.o \
+	$(BUILDDIR)/client/cl_fx.o \
+	$(BUILDDIR)/client/cl_input.o \
+	$(BUILDDIR)/client/cl_inv.o \
+	$(BUILDDIR)/client/cl_main.o \
+	$(BUILDDIR)/client/cl_newfx.o \
+	$(BUILDDIR)/client/cl_parse.o \
+	$(BUILDDIR)/client/cl_pred.o \
+	$(BUILDDIR)/client/cl_tent.o \
+	$(BUILDDIR)/client/cl_scrn.o \
+	$(BUILDDIR)/client/cl_view.o \
+	$(BUILDDIR)/client/console.o \
+	$(BUILDDIR)/client/keys.o \
+	$(BUILDDIR)/client/menu.o \
+	$(BUILDDIR)/client/snd_dma.o \
+	$(BUILDDIR)/client/snd_mem.o \
+	$(BUILDDIR)/client/snd_miniaudio.o \
+	$(BUILDDIR)/client/snd_mix.o \
+	$(BUILDDIR)/client/qmenu.o \
+	$(BUILDDIR)/client/m_flash.o \
+	\
+	$(BUILDDIR)/client/cmd.o \
+	$(BUILDDIR)/client/cmodel.o \
+	$(BUILDDIR)/client/common.o \
+	$(BUILDDIR)/client/crc.o \
+	$(BUILDDIR)/client/cvar.o \
+	$(BUILDDIR)/client/files.o \
+	$(BUILDDIR)/client/md4.o \
+	$(BUILDDIR)/client/net_chan.o \
+	\
+	$(BUILDDIR)/client/sv_ccmds.o \
+	$(BUILDDIR)/client/sv_ents.o \
+	$(BUILDDIR)/client/sv_game.o \
+	$(BUILDDIR)/client/sv_init.o \
+	$(BUILDDIR)/client/sv_main.o \
+	$(BUILDDIR)/client/sv_send.o \
+	$(BUILDDIR)/client/sv_user.o \
+	$(BUILDDIR)/client/sv_world.o \
+	\
+	$(BUILDDIR)/client/cd_null.o \
+	$(BUILDDIR)/client/q_shmacos.o \
+	$(BUILDDIR)/client/vid_menu.o \
+	$(BUILDDIR)/client/vid_dsym.o \
+	$(BUILDDIR)/client/snd_macos.o \
+	$(BUILDDIR)/client/sys_macos.o \
+	$(BUILDDIR)/client/glob.o \
+	$(BUILDDIR)/client/net_udp.o \
+	\
+	$(BUILDDIR)/client/q_shared.o \
+	$(BUILDDIR)/client/pmove.o
+
+QUAKE2_AS_OBJS = \
+	$(BUILDDIR)/client/snd_mixa.o
+
+$(BUILDDIR)/quake2 : $(QUAKE2_OBJS) $(QUAKE2_AS_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(QUAKE2_OBJS) $(QUAKE2_AS_OBJS) $(LDFLAGS)
+
+$(BUILDDIR)/client/cl_cin.o :     $(CLIENT_DIR)/cl_cin.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_ents.o :    $(CLIENT_DIR)/cl_ents.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_fx.o :      $(CLIENT_DIR)/cl_fx.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_input.o :   $(CLIENT_DIR)/cl_input.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_inv.o :     $(CLIENT_DIR)/cl_inv.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_main.o :    $(CLIENT_DIR)/cl_main.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_newfx.o :    $(CLIENT_DIR)/cl_newfx.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_parse.o :   $(CLIENT_DIR)/cl_parse.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_pred.o :    $(CLIENT_DIR)/cl_pred.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_tent.o :    $(CLIENT_DIR)/cl_tent.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_scrn.o :    $(CLIENT_DIR)/cl_scrn.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cl_view.o :    $(CLIENT_DIR)/cl_view.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/console.o :    $(CLIENT_DIR)/console.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/keys.o :       $(CLIENT_DIR)/keys.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/menu.o :       $(CLIENT_DIR)/menu.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/snd_dma.o :    $(CLIENT_DIR)/snd_dma.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/snd_mem.o :    $(CLIENT_DIR)/snd_mem.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/snd_miniaudio.o : $(CLIENT_DIR)/snd_miniaudio.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/snd_mix.o :    $(CLIENT_DIR)/snd_mix.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/qmenu.o :      $(CLIENT_DIR)/qmenu.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/m_flash.o :    $(GAME_DIR)/m_flash.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cmd.o :        $(COMMON_DIR)/cmd.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cmodel.o :     $(COMMON_DIR)/cmodel.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/common.o :     $(COMMON_DIR)/common.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/crc.o :        $(COMMON_DIR)/crc.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cvar.o :       $(COMMON_DIR)/cvar.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/files.o :      $(COMMON_DIR)/files.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/md4.o :        $(COMMON_DIR)/md4.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/net_chan.o :   $(COMMON_DIR)/net_chan.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/q_shared.o :   $(GAME_DIR)/q_shared.c
+	$(DO_DEBUG_CC)
+
+$(BUILDDIR)/client/pmove.o :      $(COMMON_DIR)/pmove.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/sv_ccmds.o :   $(SERVER_DIR)/sv_ccmds.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/sv_ents.o :    $(SERVER_DIR)/sv_ents.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/sv_game.o :    $(SERVER_DIR)/sv_game.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/sv_init.o :    $(SERVER_DIR)/sv_init.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/sv_main.o :    $(SERVER_DIR)/sv_main.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/sv_send.o :    $(SERVER_DIR)/sv_send.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/sv_user.o :    $(SERVER_DIR)/sv_user.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/sv_world.o :   $(SERVER_DIR)/sv_world.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/cd_null.o :   $(NULL_DIR)/cd_null.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/q_shmacos.o :  $(MACOS_DIR)/q_shmacos.c
+	$(DO_O_CC)
+
+$(BUILDDIR)/client/vid_menu.o :     $(LINUX_DIR)/vid_menu.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/vid_dsym.o :     $(MACOS_DIR)/vid_dsym.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/snd_macos.o :  $(MACOS_DIR)/snd_macos.m
+	$(DO_CC)
+
+$(BUILDDIR)/client/snd_mixa.o :   $(LINUX_DIR)/snd_mixa.s
+	$(DO_AS)
+
+$(BUILDDIR)/client/sys_macos.o :  $(MACOS_DIR)/sys_macos.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/glob.o :       $(LINUX_DIR)/glob.c
+	$(DO_CC)
+
+$(BUILDDIR)/client/net_udp.o :    $(LINUX_DIR)/net_udp.c
+	$(DO_CC)
+
+#############################################################################
+# DEDICATED SERVER
+#############################################################################
+
+Q2DED_OBJS = \
+	\
+	$(BUILDDIR)/ded/cmd.o \
+	$(BUILDDIR)/ded/cmodel.o \
+	$(BUILDDIR)/ded/common.o \
+	$(BUILDDIR)/ded/crc.o \
+	$(BUILDDIR)/ded/cvar.o \
+	$(BUILDDIR)/ded/files.o \
+	$(BUILDDIR)/ded/md4.o \
+	$(BUILDDIR)/ded/net_chan.o \
+	\
+	$(BUILDDIR)/ded/sv_ccmds.o \
+	$(BUILDDIR)/ded/sv_ents.o \
+	$(BUILDDIR)/ded/sv_game.o \
+	$(BUILDDIR)/ded/sv_init.o \
+	$(BUILDDIR)/ded/sv_main.o \
+	$(BUILDDIR)/ded/sv_send.o \
+	$(BUILDDIR)/ded/sv_user.o \
+	$(BUILDDIR)/ded/sv_world.o \
+	\
+	$(BUILDDIR)/ded/q_shmacos.o \
+	$(BUILDDIR)/ded/sys_macos.o \
+	$(BUILDDIR)/ded/glob.o \
+	$(BUILDDIR)/ded/net_udp.o \
+	\
+	$(BUILDDIR)/ded/q_shared.o \
+	$(BUILDDIR)/ded/pmove.o \
+	\
+	$(BUILDDIR)/ded/cl_null.o \
+	$(BUILDDIR)/ded/cd_null.o
+
+$(BUILDDIR)/q2ded : $(Q2DED_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(Q2DED_OBJS) $(LDFLAGS)
+
+$(BUILDDIR)/ded/cmd.o :        $(COMMON_DIR)/cmd.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/cmodel.o :     $(COMMON_DIR)/cmodel.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/common.o :     $(COMMON_DIR)/common.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/crc.o :        $(COMMON_DIR)/crc.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/cvar.o :       $(COMMON_DIR)/cvar.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/files.o :      $(COMMON_DIR)/files.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/md4.o :        $(COMMON_DIR)/md4.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/net_chan.o :   $(COMMON_DIR)/net_chan.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/q_shared.o :   $(GAME_DIR)/q_shared.c
+	$(DO_DED_DEBUG_CC)
+
+$(BUILDDIR)/ded/pmove.o :      $(COMMON_DIR)/pmove.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sv_ccmds.o :   $(SERVER_DIR)/sv_ccmds.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sv_ents.o :    $(SERVER_DIR)/sv_ents.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sv_game.o :    $(SERVER_DIR)/sv_game.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sv_init.o :    $(SERVER_DIR)/sv_init.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sv_main.o :    $(SERVER_DIR)/sv_main.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sv_send.o :    $(SERVER_DIR)/sv_send.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sv_user.o :    $(SERVER_DIR)/sv_user.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sv_world.o :   $(SERVER_DIR)/sv_world.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/q_shmacos.o :  $(MACOS_DIR)/q_shmacos.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/sys_macos.o :  $(MACOS_DIR)/sys_macos.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/glob.o :       $(LINUX_DIR)/glob.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/net_udp.o :    $(LINUX_DIR)/net_udp.c
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/cd_null.o     : $(NULL_DIR)/cd_null.c    
+	$(DO_DED_CC)
+
+$(BUILDDIR)/ded/cl_null.o     : $(NULL_DIR)/cl_null.c    
+	$(DO_DED_CC)
+
+#############################################################################
+# GAME
+#############################################################################
+
+GAME_OBJS = \
+	$(BUILDDIR)/game/q_shared.o \
+	$(BUILDDIR)/game/g_ai.o \
+	$(BUILDDIR)/game/p_client.o \
+	$(BUILDDIR)/game/g_cmds.o \
+	$(BUILDDIR)/game/g_svcmds.o \
+	$(BUILDDIR)/game/g_chase.o \
+	$(BUILDDIR)/game/g_combat.o \
+	$(BUILDDIR)/game/g_func.o \
+	$(BUILDDIR)/game/g_items.o \
+	$(BUILDDIR)/game/g_main.o \
+	$(BUILDDIR)/game/g_misc.o \
+	$(BUILDDIR)/game/g_monster.o \
+	$(BUILDDIR)/game/g_phys.o \
+	$(BUILDDIR)/game/g_save.o \
+	$(BUILDDIR)/game/g_spawn.o \
+	$(BUILDDIR)/game/g_target.o \
+	$(BUILDDIR)/game/g_trigger.o \
+	$(BUILDDIR)/game/g_turret.o \
+	$(BUILDDIR)/game/g_utils.o \
+	$(BUILDDIR)/game/g_weapon.o \
+	$(BUILDDIR)/game/m_actor.o \
+	$(BUILDDIR)/game/m_berserk.o \
+	$(BUILDDIR)/game/m_boss2.o \
+	$(BUILDDIR)/game/m_boss3.o \
+	$(BUILDDIR)/game/m_boss31.o \
+	$(BUILDDIR)/game/m_boss32.o \
+	$(BUILDDIR)/game/m_brain.o \
+	$(BUILDDIR)/game/m_chick.o \
+	$(BUILDDIR)/game/m_flipper.o \
+	$(BUILDDIR)/game/m_float.o \
+	$(BUILDDIR)/game/m_flyer.o \
+	$(BUILDDIR)/game/m_gladiator.o \
+	$(BUILDDIR)/game/m_gunner.o \
+	$(BUILDDIR)/game/m_hover.o \
+	$(BUILDDIR)/game/m_infantry.o \
+	$(BUILDDIR)/game/m_insane.o \
+	$(BUILDDIR)/game/m_medic.o \
+	$(BUILDDIR)/game/m_move.o \
+	$(BUILDDIR)/game/m_mutant.o \
+	$(BUILDDIR)/game/m_parasite.o \
+	$(BUILDDIR)/game/m_soldier.o \
+	$(BUILDDIR)/game/m_supertank.o \
+	$(BUILDDIR)/game/m_tank.o \
+	$(BUILDDIR)/game/p_hud.o \
+	$(BUILDDIR)/game/p_trail.o \
+	$(BUILDDIR)/game/p_view.o \
+	$(BUILDDIR)/game/p_weapon.o \
+	$(BUILDDIR)/game/m_flash.o
+
+$(BUILDDIR)/baseq2/game$(ARCH).$(SHLIBEXT) : $(GAME_OBJS)
+	$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(GAME_OBJS)
+
+$(BUILDDIR)/game/g_ai.o :        $(GAME_DIR)/g_ai.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/p_client.o :    $(GAME_DIR)/p_client.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_cmds.o :      $(GAME_DIR)/g_cmds.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_svcmds.o :    $(GAME_DIR)/g_svcmds.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_chase.o :    $(GAME_DIR)/g_chase.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_combat.o :    $(GAME_DIR)/g_combat.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_func.o :      $(GAME_DIR)/g_func.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_items.o :     $(GAME_DIR)/g_items.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_main.o :      $(GAME_DIR)/g_main.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_misc.o :      $(GAME_DIR)/g_misc.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_monster.o :   $(GAME_DIR)/g_monster.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_phys.o :      $(GAME_DIR)/g_phys.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_save.o :      $(GAME_DIR)/g_save.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_spawn.o :     $(GAME_DIR)/g_spawn.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_target.o :    $(GAME_DIR)/g_target.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_trigger.o :   $(GAME_DIR)/g_trigger.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_turret.o :    $(GAME_DIR)/g_turret.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_utils.o :     $(GAME_DIR)/g_utils.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/g_weapon.o :    $(GAME_DIR)/g_weapon.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_actor.o :     $(GAME_DIR)/m_actor.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_berserk.o :   $(GAME_DIR)/m_berserk.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_boss2.o :     $(GAME_DIR)/m_boss2.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_boss3.o :     $(GAME_DIR)/m_boss3.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_boss31.o :     $(GAME_DIR)/m_boss31.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_boss32.o :     $(GAME_DIR)/m_boss32.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_brain.o :     $(GAME_DIR)/m_brain.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_chick.o :     $(GAME_DIR)/m_chick.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_flipper.o :   $(GAME_DIR)/m_flipper.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_float.o :     $(GAME_DIR)/m_float.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_flyer.o :     $(GAME_DIR)/m_flyer.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_gladiator.o : $(GAME_DIR)/m_gladiator.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_gunner.o :    $(GAME_DIR)/m_gunner.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_hover.o :     $(GAME_DIR)/m_hover.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_infantry.o :  $(GAME_DIR)/m_infantry.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_insane.o :    $(GAME_DIR)/m_insane.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_medic.o :     $(GAME_DIR)/m_medic.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_move.o :      $(GAME_DIR)/m_move.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_mutant.o :    $(GAME_DIR)/m_mutant.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_parasite.o :  $(GAME_DIR)/m_parasite.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_soldier.o :   $(GAME_DIR)/m_soldier.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_supertank.o : $(GAME_DIR)/m_supertank.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/m_tank.o :      $(GAME_DIR)/m_tank.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/p_hud.o :       $(GAME_DIR)/p_hud.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/p_trail.o :     $(GAME_DIR)/p_trail.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/p_view.o :      $(GAME_DIR)/p_view.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/p_weapon.o :    $(GAME_DIR)/p_weapon.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/game/q_shared.o :    $(GAME_DIR)/q_shared.c
+	$(DO_SHLIB_DEBUG_CC)
+
+$(BUILDDIR)/game/m_flash.o :     $(GAME_DIR)/m_flash.c
+	$(DO_SHLIB_CC)
+
+#############################################################################
+# CTF
+#############################################################################
+
+CTF_OBJS = \
+	$(BUILDDIR)/ctf/g_ai.o \
+	$(BUILDDIR)/ctf/g_chase.o \
+	$(BUILDDIR)/ctf/g_cmds.o \
+	$(BUILDDIR)/ctf/g_combat.o \
+	$(BUILDDIR)/ctf/g_ctf.o \
+	$(BUILDDIR)/ctf/g_func.o \
+	$(BUILDDIR)/ctf/g_items.o \
+	$(BUILDDIR)/ctf/g_main.o \
+	$(BUILDDIR)/ctf/g_misc.o \
+	$(BUILDDIR)/ctf/g_monster.o \
+	$(BUILDDIR)/ctf/g_phys.o \
+	$(BUILDDIR)/ctf/g_save.o \
+	$(BUILDDIR)/ctf/g_spawn.o \
+	$(BUILDDIR)/ctf/g_svcmds.o \
+	$(BUILDDIR)/ctf/g_target.o \
+	$(BUILDDIR)/ctf/g_trigger.o \
+	$(BUILDDIR)/ctf/g_utils.o \
+	$(BUILDDIR)/ctf/g_weapon.o \
+	$(BUILDDIR)/ctf/m_move.o \
+	$(BUILDDIR)/ctf/p_client.o \
+	$(BUILDDIR)/ctf/p_hud.o \
+	$(BUILDDIR)/ctf/p_menu.o \
+	$(BUILDDIR)/ctf/p_trail.o \
+	$(BUILDDIR)/ctf/p_view.o \
+	$(BUILDDIR)/ctf/p_weapon.o \
+	$(BUILDDIR)/ctf/q_shared.o
+
+$(BUILDDIR)/ctf/game$(ARCH).$(SHLIBEXT) : $(CTF_OBJS)
+	$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(CTF_OBJS)
+
+$(BUILDDIR)/ctf/g_ai.o :       $(CTF_DIR)/g_ai.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_chase.o :    $(CTF_DIR)/g_chase.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_cmds.o :     $(CTF_DIR)/g_cmds.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_combat.o :   $(CTF_DIR)/g_combat.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_ctf.o :      $(CTF_DIR)/g_ctf.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_func.o :     $(CTF_DIR)/g_func.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_items.o :    $(CTF_DIR)/g_items.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_main.o :     $(CTF_DIR)/g_main.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_misc.o :     $(CTF_DIR)/g_misc.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_monster.o :  $(CTF_DIR)/g_monster.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_phys.o :     $(CTF_DIR)/g_phys.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_save.o :     $(CTF_DIR)/g_save.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_spawn.o :    $(CTF_DIR)/g_spawn.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_svcmds.o :   $(CTF_DIR)/g_svcmds.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_target.o :   $(CTF_DIR)/g_target.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_trigger.o :  $(CTF_DIR)/g_trigger.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_utils.o :    $(CTF_DIR)/g_utils.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/g_weapon.o :   $(CTF_DIR)/g_weapon.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/m_move.o :     $(CTF_DIR)/m_move.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/p_client.o :   $(CTF_DIR)/p_client.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/p_hud.o :      $(CTF_DIR)/p_hud.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/p_menu.o :     $(CTF_DIR)/p_menu.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/p_trail.o :    $(CTF_DIR)/p_trail.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/p_view.o :     $(CTF_DIR)/p_view.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/p_weapon.o :   $(CTF_DIR)/p_weapon.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/ctf/q_shared.o :   $(CTF_DIR)/q_shared.c
+	$(DO_SHLIB_DEBUG_CC)
+
+#############################################################################
+# XATRIX
+#############################################################################
+
+XATRIX_OBJS = \
+	$(BUILDDIR)/xatrix/g_ai.o \
+	$(BUILDDIR)/xatrix/g_cmds.o \
+	$(BUILDDIR)/xatrix/g_chase.o \
+	$(BUILDDIR)/xatrix/g_combat.o \
+	$(BUILDDIR)/xatrix/g_func.o \
+	$(BUILDDIR)/xatrix/g_items.o \
+	$(BUILDDIR)/xatrix/g_main.o \
+	$(BUILDDIR)/xatrix/g_misc.o \
+	$(BUILDDIR)/xatrix/g_monster.o \
+	$(BUILDDIR)/xatrix/g_phys.o \
+	$(BUILDDIR)/xatrix/g_save.o \
+	$(BUILDDIR)/xatrix/g_spawn.o \
+	$(BUILDDIR)/xatrix/g_svcmds.o \
+	$(BUILDDIR)/xatrix/g_target.o \
+	$(BUILDDIR)/xatrix/g_trigger.o \
+	$(BUILDDIR)/xatrix/g_turret.o \
+	$(BUILDDIR)/xatrix/g_utils.o \
+	$(BUILDDIR)/xatrix/g_weapon.o \
+	$(BUILDDIR)/xatrix/m_actor.o \
+	$(BUILDDIR)/xatrix/m_berserk.o \
+	$(BUILDDIR)/xatrix/m_boss2.o \
+	$(BUILDDIR)/xatrix/m_boss3.o \
+	$(BUILDDIR)/xatrix/m_boss31.o \
+	$(BUILDDIR)/xatrix/m_boss32.o \
+	$(BUILDDIR)/xatrix/m_boss5.o \
+	$(BUILDDIR)/xatrix/m_brain.o \
+	$(BUILDDIR)/xatrix/m_chick.o \
+	$(BUILDDIR)/xatrix/m_fixbot.o \
+	$(BUILDDIR)/xatrix/m_flash.o \
+	$(BUILDDIR)/xatrix/m_flipper.o \
+	$(BUILDDIR)/xatrix/m_float.o \
+	$(BUILDDIR)/xatrix/m_flyer.o \
+	$(BUILDDIR)/xatrix/m_gekk.o \
+	$(BUILDDIR)/xatrix/m_gladb.o \
+	$(BUILDDIR)/xatrix/m_gladiator.o \
+	$(BUILDDIR)/xatrix/m_gunner.o \
+	$(BUILDDIR)/xatrix/m_hover.o \
+	$(BUILDDIR)/xatrix/m_infantry.o \
+	$(BUILDDIR)/xatrix/m_insane.o \
+	$(BUILDDIR)/xatrix/m_medic.o \
+	$(BUILDDIR)/xatrix/m_move.o \
+	$(BUILDDIR)/xatrix/m_mutant.o \
+	$(BUILDDIR)/xatrix/m_parasite.o \
+	$(BUILDDIR)/xatrix/m_soldier.o \
+	$(BUILDDIR)/xatrix/m_supertank.o \
+	$(BUILDDIR)/xatrix/m_tank.o \
+	$(BUILDDIR)/xatrix/p_client.o \
+	$(BUILDDIR)/xatrix/p_hud.o \
+	$(BUILDDIR)/xatrix/p_trail.o \
+	$(BUILDDIR)/xatrix/p_view.o \
+	$(BUILDDIR)/xatrix/p_weapon.o \
+	$(BUILDDIR)/xatrix/q_shared.o
+
+$(BUILDDIR)/xatrix/game$(ARCH).$(SHLIBEXT) : $(XATRIX_OBJS)
+	$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(XATRIX_OBJS)
+
+$(BUILDDIR)/xatrix/g_ai.o :        $(XATRIX_DIR)/g_ai.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_cmds.o :      $(XATRIX_DIR)/g_cmds.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_chase.o :    $(XATRIX_DIR)/g_chase.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_combat.o :    $(XATRIX_DIR)/g_combat.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_func.o :      $(XATRIX_DIR)/g_func.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_items.o :     $(XATRIX_DIR)/g_items.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_main.o :      $(XATRIX_DIR)/g_main.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_misc.o :      $(XATRIX_DIR)/g_misc.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_monster.o :   $(XATRIX_DIR)/g_monster.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_phys.o :      $(XATRIX_DIR)/g_phys.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_save.o :      $(XATRIX_DIR)/g_save.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_spawn.o :     $(XATRIX_DIR)/g_spawn.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_svcmds.o :    $(XATRIX_DIR)/g_svcmds.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_target.o :    $(XATRIX_DIR)/g_target.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_trigger.o :   $(XATRIX_DIR)/g_trigger.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_turret.o :    $(XATRIX_DIR)/g_turret.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_utils.o :     $(XATRIX_DIR)/g_utils.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/g_weapon.o :    $(XATRIX_DIR)/g_weapon.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_actor.o :     $(XATRIX_DIR)/m_actor.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_berserk.o :   $(XATRIX_DIR)/m_berserk.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_boss2.o :     $(XATRIX_DIR)/m_boss2.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_boss3.o :     $(XATRIX_DIR)/m_boss3.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_boss31.o :    $(XATRIX_DIR)/m_boss31.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_boss32.o :    $(XATRIX_DIR)/m_boss32.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_boss5.o :     $(XATRIX_DIR)/m_boss5.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_brain.o :     $(XATRIX_DIR)/m_brain.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_chick.o :     $(XATRIX_DIR)/m_chick.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_fixbot.o :    $(XATRIX_DIR)/m_fixbot.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_flash.o :     $(XATRIX_DIR)/m_flash.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_flipper.o :   $(XATRIX_DIR)/m_flipper.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_float.o :     $(XATRIX_DIR)/m_float.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_flyer.o :     $(XATRIX_DIR)/m_flyer.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_gekk.o :      $(XATRIX_DIR)/m_gekk.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_gladb.o :     $(XATRIX_DIR)/m_gladb.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_gladiator.o : $(XATRIX_DIR)/m_gladiator.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_gunner.o :    $(XATRIX_DIR)/m_gunner.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_hover.o :     $(XATRIX_DIR)/m_hover.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_infantry.o :  $(XATRIX_DIR)/m_infantry.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_insane.o :    $(XATRIX_DIR)/m_insane.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_medic.o :     $(XATRIX_DIR)/m_medic.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_move.o :      $(XATRIX_DIR)/m_move.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_mutant.o :    $(XATRIX_DIR)/m_mutant.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_parasite.o :  $(XATRIX_DIR)/m_parasite.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_soldier.o :   $(XATRIX_DIR)/m_soldier.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_supertank.o : $(XATRIX_DIR)/m_supertank.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/m_tank.o :      $(XATRIX_DIR)/m_tank.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/p_client.o :    $(XATRIX_DIR)/p_client.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/p_hud.o :       $(XATRIX_DIR)/p_hud.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/p_trail.o :     $(XATRIX_DIR)/p_trail.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/p_view.o :      $(XATRIX_DIR)/p_view.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/p_weapon.o :    $(XATRIX_DIR)/p_weapon.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/xatrix/q_shared.o :    $(XATRIX_DIR)/q_shared.c
+	$(DO_SHLIB_DEBUG_CC)
+
+#############################################################################
+# ROGUE
+#############################################################################
+
+ROGUE_OBJS = \
+	$(BUILDDIR)/rogue/dm_ball.o \
+	$(BUILDDIR)/rogue/dm_tag.o \
+	$(BUILDDIR)/rogue/g_ai.o \
+	$(BUILDDIR)/rogue/g_chase.o \
+	$(BUILDDIR)/rogue/g_cmds.o \
+	$(BUILDDIR)/rogue/g_combat.o \
+	$(BUILDDIR)/rogue/g_func.o \
+	$(BUILDDIR)/rogue/g_items.o \
+	$(BUILDDIR)/rogue/g_main.o \
+	$(BUILDDIR)/rogue/g_misc.o \
+	$(BUILDDIR)/rogue/g_monster.o \
+	$(BUILDDIR)/rogue/g_newai.o \
+	$(BUILDDIR)/rogue/g_newdm.o \
+	$(BUILDDIR)/rogue/g_newfnc.o \
+	$(BUILDDIR)/rogue/g_newtarg.o \
+	$(BUILDDIR)/rogue/g_newtrig.o \
+	$(BUILDDIR)/rogue/g_newweap.o \
+	$(BUILDDIR)/rogue/g_phys.o \
+	$(BUILDDIR)/rogue/g_save.o \
+	$(BUILDDIR)/rogue/g_spawn.o \
+	$(BUILDDIR)/rogue/g_sphere.o \
+	$(BUILDDIR)/rogue/g_svcmds.o \
+	$(BUILDDIR)/rogue/g_target.o \
+	$(BUILDDIR)/rogue/g_trigger.o \
+	$(BUILDDIR)/rogue/g_turret.o \
+	$(BUILDDIR)/rogue/g_utils.o \
+	$(BUILDDIR)/rogue/g_weapon.o \
+	$(BUILDDIR)/rogue/m_actor.o \
+	$(BUILDDIR)/rogue/m_berserk.o \
+	$(BUILDDIR)/rogue/m_boss2.o \
+	$(BUILDDIR)/rogue/m_boss3.o \
+	$(BUILDDIR)/rogue/m_boss31.o \
+	$(BUILDDIR)/rogue/m_boss32.o \
+	$(BUILDDIR)/rogue/m_brain.o \
+	$(BUILDDIR)/rogue/m_carrier.o \
+	$(BUILDDIR)/rogue/m_chick.o \
+	$(BUILDDIR)/rogue/m_flash.o \
+	$(BUILDDIR)/rogue/m_flipper.o \
+	$(BUILDDIR)/rogue/m_float.o \
+	$(BUILDDIR)/rogue/m_flyer.o \
+	$(BUILDDIR)/rogue/m_gladiator.o \
+	$(BUILDDIR)/rogue/m_gunner.o \
+	$(BUILDDIR)/rogue/m_hover.o \
+	$(BUILDDIR)/rogue/m_infantry.o \
+	$(BUILDDIR)/rogue/m_insane.o \
+	$(BUILDDIR)/rogue/m_medic.o \
+	$(BUILDDIR)/rogue/m_move.o \
+	$(BUILDDIR)/rogue/m_mutant.o \
+	$(BUILDDIR)/rogue/m_parasite.o \
+	$(BUILDDIR)/rogue/m_soldier.o \
+	$(BUILDDIR)/rogue/m_stalker.o \
+	$(BUILDDIR)/rogue/m_supertank.o \
+	$(BUILDDIR)/rogue/m_tank.o \
+	$(BUILDDIR)/rogue/m_turret.o \
+	$(BUILDDIR)/rogue/m_widow.o \
+	$(BUILDDIR)/rogue/m_widow2.o \
+	$(BUILDDIR)/rogue/p_client.o \
+	$(BUILDDIR)/rogue/p_hud.o \
+	$(BUILDDIR)/rogue/p_trail.o \
+	$(BUILDDIR)/rogue/p_view.o \
+	$(BUILDDIR)/rogue/p_weapon.o \
+	$(BUILDDIR)/rogue/q_shared.o
+
+$(BUILDDIR)/rogue/game$(ARCH).$(SHLIBEXT) : $(ROGUE_OBJS)
+	$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(ROGUE_OBJS)
+
+$(BUILDDIR)/rogue/dm_ball.o :      $(ROGUE_DIR)/dm_ball.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/dm_tag.o :       $(ROGUE_DIR)/dm_tag.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_ai.o :         $(ROGUE_DIR)/g_ai.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_chase.o :      $(ROGUE_DIR)/g_chase.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_cmds.o :       $(ROGUE_DIR)/g_cmds.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_combat.o :     $(ROGUE_DIR)/g_combat.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_func.o :       $(ROGUE_DIR)/g_func.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_items.o :      $(ROGUE_DIR)/g_items.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_main.o :       $(ROGUE_DIR)/g_main.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_misc.o :       $(ROGUE_DIR)/g_misc.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_monster.o :    $(ROGUE_DIR)/g_monster.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_newai.o :      $(ROGUE_DIR)/g_newai.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_newdm.o :      $(ROGUE_DIR)/g_newdm.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_newfnc.o :     $(ROGUE_DIR)/g_newfnc.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_newtarg.o :    $(ROGUE_DIR)/g_newtarg.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_newtrig.o :    $(ROGUE_DIR)/g_newtrig.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_newweap.o :    $(ROGUE_DIR)/g_newweap.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_phys.o :       $(ROGUE_DIR)/g_phys.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_save.o :       $(ROGUE_DIR)/g_save.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_spawn.o :      $(ROGUE_DIR)/g_spawn.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_sphere.o :     $(ROGUE_DIR)/g_sphere.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_svcmds.o :     $(ROGUE_DIR)/g_svcmds.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_target.o :     $(ROGUE_DIR)/g_target.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_trigger.o :    $(ROGUE_DIR)/g_trigger.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_turret.o :     $(ROGUE_DIR)/g_turret.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_utils.o :      $(ROGUE_DIR)/g_utils.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/g_weapon.o :     $(ROGUE_DIR)/g_weapon.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_actor.o :      $(ROGUE_DIR)/m_actor.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_berserk.o :    $(ROGUE_DIR)/m_berserk.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_boss2.o :      $(ROGUE_DIR)/m_boss2.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_boss3.o :      $(ROGUE_DIR)/m_boss3.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_boss31.o :     $(ROGUE_DIR)/m_boss31.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_boss32.o :     $(ROGUE_DIR)/m_boss32.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_brain.o :      $(ROGUE_DIR)/m_brain.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_carrier.o :    $(ROGUE_DIR)/m_carrier.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_chick.o :      $(ROGUE_DIR)/m_chick.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_flash.o :      $(ROGUE_DIR)/m_flash.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_flipper.o :    $(ROGUE_DIR)/m_flipper.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_float.o :      $(ROGUE_DIR)/m_float.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_flyer.o :      $(ROGUE_DIR)/m_flyer.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_gladiator.o :  $(ROGUE_DIR)/m_gladiator.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_gunner.o :     $(ROGUE_DIR)/m_gunner.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_hover.o :      $(ROGUE_DIR)/m_hover.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_infantry.o :   $(ROGUE_DIR)/m_infantry.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_insane.o :     $(ROGUE_DIR)/m_insane.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_medic.o :      $(ROGUE_DIR)/m_medic.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_move.o :       $(ROGUE_DIR)/m_move.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_mutant.o :     $(ROGUE_DIR)/m_mutant.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_parasite.o :   $(ROGUE_DIR)/m_parasite.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_soldier.o :    $(ROGUE_DIR)/m_soldier.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_stalker.o :    $(ROGUE_DIR)/m_stalker.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_supertank.o :  $(ROGUE_DIR)/m_supertank.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_tank.o :       $(ROGUE_DIR)/m_tank.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_turret.o :     $(ROGUE_DIR)/m_turret.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_widow.o :      $(ROGUE_DIR)/m_widow.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/m_widow2.o :     $(ROGUE_DIR)/m_widow2.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/p_client.o :     $(ROGUE_DIR)/p_client.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/p_hud.o :        $(ROGUE_DIR)/p_hud.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/p_trail.o :      $(ROGUE_DIR)/p_trail.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/p_view.o :       $(ROGUE_DIR)/p_view.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/p_weapon.o :     $(ROGUE_DIR)/p_weapon.c
+	$(DO_SHLIB_CC)
+
+$(BUILDDIR)/rogue/q_shared.o :     $(ROGUE_DIR)/q_shared.c
+	$(DO_SHLIB_DEBUG_CC)
+
+#############################################################################
+# REF_VK
+#############################################################################
+
+REF_VK_OBJS = \
+	$(BUILDDIR)/ref_vk/vk_buffer.o \
+	$(BUILDDIR)/ref_vk/vk_cmd.o \
+	$(BUILDDIR)/ref_vk/vk_common.o \
+	$(BUILDDIR)/ref_vk/vk_device.o \
+	$(BUILDDIR)/ref_vk/vk_draw.o \
+	$(BUILDDIR)/ref_vk/vk_image.o \
+	$(BUILDDIR)/ref_vk/vk_imp.o \
+	$(BUILDDIR)/ref_vk/vk_light.o \
+	$(BUILDDIR)/ref_vk/vk_mem_alloc.o \
+	$(BUILDDIR)/ref_vk/vk_mesh.o \
+	$(BUILDDIR)/ref_vk/vk_model.o \
+	$(BUILDDIR)/ref_vk/vk_pipeline.o \
+	$(BUILDDIR)/ref_vk/vk_rmain.o \
+	$(BUILDDIR)/ref_vk/vk_rmisc.o \
+	$(BUILDDIR)/ref_vk/vk_rsurf.o \
+	$(BUILDDIR)/ref_vk/vk_shaders.o \
+	$(BUILDDIR)/ref_vk/vk_swapchain.o \
+	$(BUILDDIR)/ref_vk/vk_validation.o \
+	$(BUILDDIR)/ref_vk/vk_warp.o \
+	\
+	$(BUILDDIR)/ref_vk/q_shared.o \
+	$(BUILDDIR)/ref_vk/q_shlinux.o \
+	$(BUILDDIR)/ref_vk/win_macos.o \
+	$(BUILDDIR)/ref_vk/glob.o
+
+$(BUILDDIR)/ref_vk.$(SHLIBEXT) : $(REF_VK_OBJS)
+	$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(REF_VK_OBJS) $(VKLDFLAGS)
+
+$(BUILDDIR)/ref_vk/vk_buffer.o :        $(REF_VK_DIR)/vk_buffer.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_cmd.o :       $(REF_VK_DIR)/vk_cmd.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_common.o :      $(REF_VK_DIR)/vk_common.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_device.o :       $(REF_VK_DIR)/vk_device.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_draw.o :        $(REF_VK_DIR)/vk_draw.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_image.o :       $(REF_VK_DIR)/vk_image.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_light.o :       $(REF_VK_DIR)/vk_light.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_mem_alloc.o :       $(REF_VK_DIR)/vk_mem_alloc.cpp
+	$(DO_VK_SHLIB_CPP)
+
+$(BUILDDIR)/ref_vk/vk_mesh.o :       $(REF_VK_DIR)/vk_mesh.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_model.o :        $(REF_VK_DIR)/vk_model.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_pipeline.o :        $(REF_VK_DIR)/vk_pipeline.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_rmain.o :        $(REF_VK_DIR)/vk_rmain.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_rmisc.o :        $(REF_VK_DIR)/vk_rmisc.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_rsurf.o :        $(REF_VK_DIR)/vk_rsurf.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_shaders.o :        $(REF_VK_DIR)/vk_shaders.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_swapchain.o :        $(REF_VK_DIR)/vk_swapchain.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_validation.o :        $(REF_VK_DIR)/vk_validation.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/vk_warp.o :        $(REF_VK_DIR)/vk_warp.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/q_shared.o :       $(GAME_DIR)/q_shared.c
+	$(DO_SHLIB_DEBUG_CC)
+
+$(BUILDDIR)/ref_vk/q_shlinux.o :      $(MACOS_DIR)/q_shmacos.c
+	$(DO_VK_SHLIB_O_CC)
+
+$(BUILDDIR)/ref_vk/vk_imp.o :       $(MACOS_DIR)/vk_imp.m
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/glob.o :           $(LINUX_DIR)/glob.c
+	$(DO_VK_SHLIB_CC)
+
+$(BUILDDIR)/ref_vk/win_macos.o :           $(MACOS_DIR)/win_macos.m
+	$(DO_VK_SHLIB_CC)
+
+#############################################################################
+# XCODE
+#############################################################################
+
+debug-xcode:
 	xcodebuild -workspace vkQuake2.xcworkspace -scheme vkQuake2 -configuration Debug build
-release:
+release-xcode:
 	xcodebuild -workspace vkQuake2.xcworkspace -scheme vkQuake2 -configuration Release build
-clean:
-	xcodebuild -workspace vkQuake2.xcworkspace -scheme vkQuake2 -configuration Debug clean
-	xcodebuild -workspace vkQuake2.xcworkspace -scheme vkQuake2 -configuration Release clean
+clean-xcode:
+	-xcodebuild -workspace vkQuake2.xcworkspace -scheme vkQuake2 -configuration Debug clean
+	-xcodebuild -workspace vkQuake2.xcworkspace -scheme vkQuake2 -configuration Release clean
 
-.PHONY: debug release clean
+#############################################################################
+# MISC
+#############################################################################
+
+clean: clean-debug clean-release clean-xcode
+
+clean-debug:
+	$(MAKE) clean2 BUILDDIR=$(BUILD_DEBUG_DIR) CFLAGS="$(DEBUG_CFLAGS)"
+
+clean-release:
+	$(MAKE) clean2 BUILDDIR=$(BUILD_RELEASE_DIR) CFLAGS="$(DEBUG_CFLAGS)"
+
+clean2:
+	-rm -f \
+	$(QUAKE2_OBJS) \
+	$(Q2DED_OBJS) \
+	$(QUAKE2_AS_OBJS) \
+	$(GAME_OBJS) \
+	$(CTF_OBJS) \
+	$(XATRIX_OBJS) \
+	$(ROGUE_OBJS) \
+	$(REF_VK_OBJS)


### PR DESCRIPTION
As discussed in #78, created Makefile to just use the Command Line Tools in MacOS rather than a full XCode install.  Makefile based from Linux version but removed all Linux specific information to focus on just the MacOS dependencies as much as possible.  Seems to work (played a couple of levels, maybe requires a careful check).  Happy for suggestions or improvements.