### PR TITLE
Update Makefile to detect ppc64le correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ xcuserdata
 macos/vkQuake2
 debugx64
 releasex64
+debugppc64le
+releaseppc64le
 Debug
 Release
 Quake2

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -18,13 +18,21 @@ else
 GLIBC=
 endif
 
-ifneq (,$(findstring alpha,$(shell uname -m)))
-ARCH=axp
-RPMARCH=alpha
+KERNEL_ARCH=$(shell uname -m)
+
+ifeq ($(KERNEL_ARCH),x86_64)
+  ARCH=x64
+  RPMARCH=i386
+else ifeq ($(KERNEL_ARCH),ppc64le)
+  ARCH=ppc64le
+  RPMARCH=ppc64le
+else ifneq (,$(findstring alpha,$(KERNEL_ARCH)))
+  ARCH=axp
+  RPMARCH=alpha
 else
-ARCH=x64
-RPMARCH=i386
+  $(error "Unsupported ARCH: ${KERNEL_ARCH}")
 endif
+
 NOARCH=noarch
 
 MOUNT_DIR=..


### PR DESCRIPTION
The architecture check in Makefile assumes the host is either alpha or i386. This PR updates the Makefile to correctly detect i386, alpha and ppc64le