### PR TITLE
Add ppc64le build for Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ xcuserdata
 macos/vkQuake2
 debugx64
 releasex64
+debugppc64le
+releaseppc64le
 Debug
 Release
 Quake2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,18 @@ before_install:
 matrix:
   include:
     - os: linux
+      dist: bionic
       arch: ppc64le
       compiler: g++
       sudo: required
       install:
-        - export VULKAN_SDK=$TRAVIS_BUILD_DIR/$VK_VERSION/x86_64
+        - export VULKAN_SDK=$TRAVIS_BUILD_DIR/$VK_VERSION/ppc64le
         - sudo apt-get -qq update
-        - sudo apt-get install -y make gcc g++ mesa-common-dev libglu1-mesa-dev libxxf86dga-dev libxxf86vm-dev libasound2-dev libx11-dev libxcb1-dev
-        - curl -L -v -o vulkansdk-linux-ppc64le-$VK_VERSION.tar.gz -O https://sdk.lunarg.com/sdk/download/$VK_VERSION/linux/vulkansdk-linux-ppc64le-$VK_VERSION.tar.gz?Human=true
+        - sudo apt-get install -y make gcc g++ mesa-common-dev libglu1-mesa-dev libxxf86dga-dev libxxf86vm-dev libasound2-dev libx11-dev libxcb1-dev 
+        - curl -L -v -o vulkansdk-linux-ppc64le-$VK_VERSION.tar.gz -O https://raw.githubusercontent.com/runlevel5/vulkansdk-linux-ppc64le/master/vulkansdk-linux-ppc64le-$VK_VERSION.tar.gz 
         - tar zxf vulkansdk-linux-ppc64le-$VK_VERSION.tar.gz
       script:
-        - cd linux
+        - cd $TRAVIS_BUILD_DIR/linux
         - make clean debug
         - make clean release
     - os: linux
@@ -47,7 +48,6 @@ matrix:
         - cd macos
         - make clean-xcode debug-xcode
         - make clean-xcode release-xcode
-
 notifications:
   email:
     recipients:

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -18,13 +18,21 @@ else
 GLIBC=
 endif
 
-ifneq (,$(findstring alpha,$(shell uname -m)))
-ARCH=axp
-RPMARCH=alpha
+KERNEL_ARCH=$(shell uname -m)
+
+ifeq ($(KERNEL_ARCH),x86_64)
+  ARCH=x64
+  RPMARCH=i386
+else ifeq ($(KERNEL_ARCH),ppc64le)
+  ARCH=ppc64le
+  RPMARCH=ppc64le
+else ifneq (,$(findstring alpha,$(KERNEL_ARCH)))
+  ARCH=axp
+  RPMARCH=alpha
 else
-ARCH=x64
-RPMARCH=i386
+  $(error "Unsupported ARCH: ${KERNEL_ARCH}")
 endif
+
 NOARCH=noarch
 
 MOUNT_DIR=..

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -78,7 +78,13 @@ XCFLAGS=
 
 GLLDFLAGS=-L/usr/X11R6/lib -L/usr/local/lib -L$(MESA_DIR)/lib -lX11 -lXext -lvga -lm
 GLXLDFLAGS=-L/usr/X11R6/lib -L/usr/local/lib -L$(MESA_DIR)/lib -lX11 -lXext -lXxf86dga -lXxf86vm -lm
+
+ifeq ($(ARCH),ppc64le)
+VKLDFLAGS=-L/usr/X11R6/lib -L$(VULKAN_SDK)/lib64 -L/usr/local/lib -lX11 -lXext -lXxf86dga -lXxf86vm -lm -lvulkan -lstdc++
+else
 VKLDFLAGS=-L/usr/X11R6/lib -L$(VULKAN_SDK)/lib -L/usr/local/lib -lX11 -lXext -lXxf86dga -lXxf86vm -lm -lvulkan -lstdc++
+endif
+
 GLCFLAGS=-I$(MESA_DIR)/include -I/usr/include/glide
 VKCFLAGS=-I$(VULKAN_SDK)/include
 


### PR DESCRIPTION
## Context

The Vulkan SDK tarball does not come with ppc64le binaries (:man_shrugging: I have no idea why they prepare a ppc64le tarball in the first place...). One workaround is to compile all SDK from source while waiting for the upstream binary tarball (lodged request https://vulkan.lunarg.com/issue/view/5e8fe31286da81205ba4b137). That solution is a huge drawback, that is slow compilation time on travis ci. So I decided to build those binaries on my box and package them up (Ref: https://github.com/runlevel5/vulkansdk-linux-ppc64le)