### PR TITLE
Added support for VK_EXT_full_screen_exclusive and removed VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT dependency.

### DIFF
--- a/ref_vk/qvk.h
+++ b/ref_vk/qvk.h
@@ -200,6 +200,10 @@ typedef enum
 	RP_COUNT = 3
 } qvkrenderpasstype_t;
 
+// Vulkan constants: command and dynamic buffer count
+#define NUM_CMDBUFFERS 2
+#define NUM_DYNBUFFERS 2
+
 // Vulkan instance
 extern VkInstance vk_instance;
 // Vulkan surface
@@ -213,7 +217,7 @@ extern qvkswapchain_t vk_swapchain;
 // Vulkan command buffer currently in use
 extern VkCommandBuffer vk_activeCmdbuffer;
 // Vulkan command pools
-extern VkCommandPool vk_commandPool;
+extern VkCommandPool vk_commandPool[NUM_CMDBUFFERS];
 extern VkCommandPool vk_transferCommandPool;
 // Vulkan descriptor pool
 extern VkDescriptorPool vk_descriptorPool;

--- a/ref_vk/vk_cmd.c
+++ b/ref_vk/vk_cmd.c
@@ -67,8 +67,7 @@ VkResult QVk_CreateCommandPool(VkCommandPool *commandPool, uint32_t queueFamilyI
 	VkCommandPoolCreateInfo cpCreateInfo = {
 		.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
 		.pNext = NULL,
-		// allow the command pool to be explicitly reset without reallocating it manually during recording each frame
-		.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+		.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
 		.queueFamilyIndex = queueFamilyIndex
 	};
 

--- a/ref_vk/vk_common.c
+++ b/ref_vk/vk_common.c
@@ -1516,13 +1516,17 @@ void QVk_Shutdown( void )
 */
 qboolean QVk_Init()
 {
-	PFN_vkEnumerateInstanceVersion vkEnumerateInstanceVersion = (PFN_vkEnumerateInstanceVersion)vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceVersion");
 	uint32_t instanceVersion = VK_API_VERSION_1_0;
+
+// MoltenVK device only provides 1.0 support as of SDK 1.2.135.0, so no need to further enumerate instance version.
+#ifndef __APPLE__
+	PFN_vkEnumerateInstanceVersion vkEnumerateInstanceVersion = (PFN_vkEnumerateInstanceVersion)vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceVersion");
 
 	if (vkEnumerateInstanceVersion)
 	{
 		VK_VERIFY(vkEnumerateInstanceVersion(&instanceVersion));
 	}
+#endif
 
 	VkApplicationInfo appInfo = {
 		.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,

--- a/ref_vk/vk_common.c
+++ b/ref_vk/vk_common.c
@@ -889,7 +889,7 @@ static void CreateDescriptorPool()
 		// sampler
 		{
 			.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-			.descriptorCount = MAX_VKTEXTURES + 1
+			.descriptorCount = MAX_VKTEXTURES + 32
 		}
 	};
 

--- a/ref_vk/vk_common.c
+++ b/ref_vk/vk_common.c
@@ -1561,7 +1561,7 @@ qboolean QVk_Init()
 	vk_config.triangle_fan_index_max_usage = 0;
 	vk_config.triangle_fan_index_count = TRIANGLE_FAN_INDEX_CNT;
 	vk_config.vk_ext_full_screen_exclusive_available = false;
-	vk_config.vk_full_screen_exclusive_supported = false;
+	vk_config.vk_full_screen_exclusive_enabled = false;
 	vk_config.vk_full_screen_exclusive_acquired = false;
 
 	Vkimp_GetSurfaceExtensions(NULL, &extCount);
@@ -1883,7 +1883,7 @@ VkResult QVk_BeginFrame()
 	ReleaseSwapBuffers();
 
 #ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
-	if (vk_config.vk_full_screen_exclusive_supported)
+	if (vk_config.vk_full_screen_exclusive_enabled)
 	{
 		VkResult res;
 		if (vid_fullscreen->value && !vk_config.vk_full_screen_exclusive_acquired)

--- a/ref_vk/vk_common.c
+++ b/ref_vk/vk_common.c
@@ -172,7 +172,7 @@ PFN_vkSetDebugUtilsObjectTagEXT qvkSetDebugUtilsObjectTagEXT;
 PFN_vkCmdBeginDebugUtilsLabelEXT qvkCmdBeginDebugUtilsLabelEXT;
 PFN_vkCmdEndDebugUtilsLabelEXT qvkCmdEndDebugUtilsLabelEXT;
 PFN_vkCmdInsertDebugUtilsLabelEXT qvkInsertDebugUtilsLabelEXT;
-#ifdef FS_EXCLUSIVE
+#ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
 PFN_vkAcquireFullScreenExclusiveModeEXT qvkAcquireFullScreenExclusiveModeEXT;
 PFN_vkReleaseFullScreenExclusiveModeEXT qvkReleaseFullScreenExclusiveModeEXT;
 #endif
@@ -1654,7 +1654,7 @@ qboolean QVk_Init()
 	qvkCmdBeginDebugUtilsLabelEXT = (PFN_vkCmdBeginDebugUtilsLabelEXT)vkGetInstanceProcAddr(vk_instance, "vkCmdBeginDebugUtilsLabelEXT");
 	qvkCmdEndDebugUtilsLabelEXT   = (PFN_vkCmdEndDebugUtilsLabelEXT)vkGetInstanceProcAddr(vk_instance, "vkCmdEndDebugUtilsLabelEXT");
 	qvkInsertDebugUtilsLabelEXT   = (PFN_vkCmdInsertDebugUtilsLabelEXT)vkGetInstanceProcAddr(vk_instance, "vkCmdInsertDebugUtilsLabelEXT");
-#ifdef FS_EXCLUSIVE
+#ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
 	qvkAcquireFullScreenExclusiveModeEXT = (PFN_vkAcquireFullScreenExclusiveModeEXT)vkGetInstanceProcAddr(vk_instance, "vkAcquireFullScreenExclusiveModeEXT");
 	qvkReleaseFullScreenExclusiveModeEXT = (PFN_vkReleaseFullScreenExclusiveModeEXT)vkGetInstanceProcAddr(vk_instance, "vkReleaseFullScreenExclusiveModeEXT");
 #endif
@@ -1882,7 +1882,7 @@ VkResult QVk_BeginFrame()
 
 	ReleaseSwapBuffers();
 
-#ifdef FS_EXCLUSIVE
+#ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
 	if (vk_config.vk_full_screen_exclusive_supported)
 	{
 		VkResult res;

--- a/ref_vk/vk_device.c
+++ b/ref_vk/vk_device.c
@@ -35,7 +35,9 @@ static qboolean deviceExtensionsSupported(const VkPhysicalDevice *physicalDevice
 		for (uint32_t i = 0; i < availableExtCount; ++i)
 		{
 			vk_khr_swapchain_extension_available |= strcmp(extensions[i].extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0;
+#ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
 			vk_config.vk_ext_full_screen_exclusive_available |= strcmp(extensions[i].extensionName, VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME) == 0;
+#endif
 		}
 
 		free(extensions);

--- a/ref_vk/vk_device.c
+++ b/ref_vk/vk_device.c
@@ -35,6 +35,7 @@ static qboolean deviceExtensionsSupported(const VkPhysicalDevice *physicalDevice
 		for (uint32_t i = 0; i < availableExtCount; ++i)
 		{
 			vk_khr_swapchain_extension_available |= strcmp(extensions[i].extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0;
+			vk_config.vk_ext_full_screen_exclusive_available |= strcmp(extensions[i].extensionName, VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME) == 0;
 		}
 
 		free(extensions);
@@ -201,13 +202,13 @@ static VkResult createLogicalDevice()
 		queueCreateInfo[numQueues++].queueFamilyIndex = vk_device.transferFamilyIndex;
 	}
 
-	const char *deviceExtensions[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+	const char *deviceExtensions[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME };
 
 	VkDeviceCreateInfo deviceCreateInfo = {
 		.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
 		.pEnabledFeatures = &wantedDeviceFeatures,
 		.ppEnabledExtensionNames = deviceExtensions,
-		.enabledExtensionCount = 1,
+		.enabledExtensionCount = vk_config.vk_ext_full_screen_exclusive_available ? 2 : 1,
 		.enabledLayerCount = 0,
 		.ppEnabledLayerNames = NULL,
 		.queueCreateInfoCount = numQueues,

--- a/ref_vk/vk_device.c
+++ b/ref_vk/vk_device.c
@@ -204,8 +204,13 @@ static VkResult createLogicalDevice()
 		queueCreateInfo[numQueues++].queueFamilyIndex = vk_device.transferFamilyIndex;
 	}
 
-	const char *deviceExtensions[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME };
-
+	const char *deviceExtensions[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME
+#ifdef VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME
+	, VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME
+	};
+#else
+	};
+#endif
 	VkDeviceCreateInfo deviceCreateInfo = {
 		.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
 		.pEnabledFeatures = &wantedDeviceFeatures,

--- a/ref_vk/vk_image.c
+++ b/ref_vk/vk_image.c
@@ -466,6 +466,8 @@ void QVk_ReadPixels(uint8_t *dstBuffer, uint32_t width, uint32_t height)
 {
 	qvkbuffer_t buff;
 	VkCommandBuffer cmdBuffer;
+	extern int vk_activeBufferIdx;
+
 	qvkbufferopts_t buffOpts = {
 		.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 		.reqMemFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
@@ -480,11 +482,10 @@ void QVk_ReadPixels(uint8_t *dstBuffer, uint32_t width, uint32_t height)
 	};
 
 	VK_VERIFY(QVk_CreateBuffer(width * height * 4, &buff, buffOpts));
-	cmdBuffer = QVk_CreateCommandBuffer(&vk_commandPool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
+	cmdBuffer = QVk_CreateCommandBuffer(&vk_commandPool[vk_activeBufferIdx], VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 	VK_VERIFY(QVk_BeginCommand(&cmdBuffer));
 	
 	// transition the current swapchain image to be a source of data transfer to our buffer
-	extern int vk_activeBufferIdx;
 	VkImageMemoryBarrier imgBarrier = {
 		.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
 		.pNext = NULL,

--- a/ref_vk/vk_local.h
+++ b/ref_vk/vk_local.h
@@ -322,6 +322,9 @@ typedef struct
 	uint32_t    triangle_fan_index_usage;
 	uint32_t    triangle_fan_index_max_usage;
 	uint32_t    triangle_fan_index_count;
+	qboolean    vk_ext_full_screen_exclusive_available;
+	qboolean    vk_full_screen_exclusive_supported;
+	qboolean    vk_full_screen_exclusive_acquired;
 } vkconfig_t;
 
 #define MAX_LIGHTMAPS 128
@@ -345,6 +348,7 @@ typedef struct
 	qboolean stereo_enabled;
 
 	VkPipeline current_pipeline;
+	VkSurfaceFullScreenExclusiveInfoEXT full_screen_exclusive_info;
 } vkstate_t;
 
 extern vkconfig_t  vk_config;
@@ -369,6 +373,10 @@ IMPLEMENTATION SPECIFIC FUNCTIONS
 ====================================================================
 */
 
+#ifdef _WIN32
+#define FS_EXCLUSIVE
+#endif
+
 void		Vkimp_BeginFrame( float camera_separation );
 void		Vkimp_EndFrame( void );
 int 		Vkimp_Init( void *hinstance, void *hWnd );
@@ -379,5 +387,6 @@ void		Vkimp_EnableLogging( qboolean enable );
 void		Vkimp_LogNewFrame( void );
 void		Vkimp_GetSurfaceExtensions(char **extensions, uint32_t *extCount);
 VkResult	Vkimp_CreateSurface(void);
+VkSurfaceCapabilitiesKHR	Vkimp_SetupFullScreenExclusive();
 
 #endif

--- a/ref_vk/vk_local.h
+++ b/ref_vk/vk_local.h
@@ -348,7 +348,9 @@ typedef struct
 	qboolean stereo_enabled;
 
 	VkPipeline current_pipeline;
+#ifdef _WIN32
 	VkSurfaceFullScreenExclusiveInfoEXT full_screen_exclusive_info;
+#endif
 } vkstate_t;
 
 extern vkconfig_t  vk_config;

--- a/ref_vk/vk_local.h
+++ b/ref_vk/vk_local.h
@@ -388,6 +388,6 @@ void		Vkimp_EnableLogging( qboolean enable );
 void		Vkimp_LogNewFrame( void );
 void		Vkimp_GetSurfaceExtensions(char **extensions, uint32_t *extCount);
 VkResult	Vkimp_CreateSurface(void);
-VkSurfaceCapabilitiesKHR	Vkimp_SetupFullScreenExclusive();
+VkSurfaceCapabilitiesKHR	Vkimp_SetupFullScreenExclusive(void);
 
 #endif

--- a/ref_vk/vk_local.h
+++ b/ref_vk/vk_local.h
@@ -373,8 +373,9 @@ IMPLEMENTATION SPECIFIC FUNCTIONS
 ====================================================================
 */
 
+// Windows-only feature for now
 #ifdef _WIN32
-#define FS_EXCLUSIVE
+#define FULL_SCREEN_EXCLUSIVE_ENABLED
 #endif
 
 void		Vkimp_BeginFrame( float camera_separation );

--- a/ref_vk/vk_local.h
+++ b/ref_vk/vk_local.h
@@ -323,7 +323,7 @@ typedef struct
 	uint32_t    triangle_fan_index_max_usage;
 	uint32_t    triangle_fan_index_count;
 	qboolean    vk_ext_full_screen_exclusive_available;
-	qboolean    vk_full_screen_exclusive_supported;
+	qboolean    vk_full_screen_exclusive_enabled;
 	qboolean    vk_full_screen_exclusive_acquired;
 } vkconfig_t;
 

--- a/ref_vk/vk_rmain.c
+++ b/ref_vk/vk_rmain.c
@@ -1111,6 +1111,7 @@ qboolean R_SetMode (void)
 	vk_mip_nearfilter->modified = false;
 	vk_sampleshading->modified = false;
 	vk_vsync->modified = false;
+	vk_modulate->modified = false;
 	vk_device_idx->modified = false;
 	vk_picmip->modified = false;
 	// refresh texture samplers

--- a/ref_vk/vk_rmisc.c
+++ b/ref_vk/vk_rmisc.c
@@ -268,8 +268,10 @@ void Vk_Strings_f(void)
 	{
 		ri.Con_Printf(PRINT_ALL, "%s ", vk_config.extensions[i++]);
 	}
+#ifdef VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME
 	if (vk_config.vk_ext_full_screen_exclusive_available)
 		ri.Con_Printf(PRINT_ALL, "%s ", VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME);
+#endif
 	ri.Con_Printf(PRINT_ALL, "\nEnabled layers: ");
 
 	i = 0;

--- a/ref_vk/vk_rmisc.c
+++ b/ref_vk/vk_rmisc.c
@@ -230,7 +230,7 @@ void Vk_Strings_f(void)
 	}
 	ri.Con_Printf(PRINT_ALL, "Using device #%d:\n", usedDevice);
 	ri.Con_Printf(PRINT_ALL, "   deviceName: %s\n", vk_device.properties.deviceName);
-	ri.Con_Printf(PRINT_ALL, "   resolution: %dx%d%s", vid.width, vid.height, vid_fullscreen->value ? " fullscreen" : "");
+	ri.Con_Printf(PRINT_ALL, "   resolution: %dx%d%s%s", vid.width, vid.height, vid_fullscreen->value ? " fullscreen" : "", vk_config.vk_full_screen_exclusive_acquired ? " exclusive" : "");
 	if (msaa > 0)
 		ri.Con_Printf(PRINT_ALL, " (MSAAx%d)\n", 2 << (msaa - 1));
 	else
@@ -268,6 +268,8 @@ void Vk_Strings_f(void)
 	{
 		ri.Con_Printf(PRINT_ALL, "%s ", vk_config.extensions[i++]);
 	}
+	if (vk_config.vk_ext_full_screen_exclusive_available)
+		ri.Con_Printf(PRINT_ALL, "%s ", VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME);
 	ri.Con_Printf(PRINT_ALL, "\nEnabled layers: ");
 
 	i = 0;

--- a/ref_vk/vk_swapchain.c
+++ b/ref_vk/vk_swapchain.c
@@ -121,7 +121,7 @@ VkResult QVk_CreateSwapchain()
 	VkPresentModeKHR *presentModes = NULL;
 	uint32_t formatCount, presentModesCount;
 
-#ifdef FS_EXCLUSIVE
+#ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
 	surfaceCaps = Vkimp_SetupFullScreenExclusive();
 #endif
 
@@ -200,7 +200,7 @@ VkResult QVk_CreateSwapchain()
 		.oldSwapchain = oldSwapchain
 	};
 
-#ifdef FS_EXCLUSIVE
+#ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
 	if (vk_config.vk_full_screen_exclusive_supported)
 	{
 		scCreateInfo.pNext = &vk_state.full_screen_exclusive_info;

--- a/ref_vk/vk_swapchain.c
+++ b/ref_vk/vk_swapchain.c
@@ -224,11 +224,12 @@ VkResult QVk_CreateSwapchain()
 	ri.Con_Printf(PRINT_ALL, "...trying swapchain image format: %d\n", vk_swapchain.format);
 
 	VkResult res = vkCreateSwapchainKHR(vk_device.logical, &scCreateInfo, NULL, &vk_swapchain.sc);
-	// "In some cases, swapchain creation may fail if exclusive full - screen mode is requested for application control, 
-	// but for some implementation - specific reason exclusive full - screen access is unavailable for the particular combination
+	// "In some cases, swapchain creation may fail if exclusive full-screen mode is requested for application control,
+	// but for some implementation-specific reason exclusive full-screen access is unavailable for the particular combination
 	// of parameters provided. If this occurs, VK_ERROR_INITIALIZATION_FAILED will be returned."
 	//
 	// This seems to affect at least a certain AMD Vega + Intel combination when running on a TV, so disable fullscreen exclusive and try again.
+#ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
 	if (vk_config.vk_full_screen_exclusive_enabled && res == VK_ERROR_INITIALIZATION_FAILED)
 	{
 		ri.Con_Printf(PRINT_ALL, "...received VK_ERROR_INITIALIZATION_FAILED from vkCreateSwapchainKHR() - disabling fullscreen exclusive!\n");
@@ -236,6 +237,8 @@ VkResult QVk_CreateSwapchain()
 		res = vkCreateSwapchainKHR(vk_device.logical, &scCreateInfo, NULL, &vk_swapchain.sc);
 		vk_config.vk_full_screen_exclusive_enabled = false;
 	}
+#endif
+
 	if (res != VK_SUCCESS)
 		return res;
 

--- a/ref_vk/vk_swapchain.c
+++ b/ref_vk/vk_swapchain.c
@@ -122,7 +122,10 @@ VkResult QVk_CreateSwapchain()
 	uint32_t formatCount, presentModesCount;
 
 #ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
-	surfaceCaps = Vkimp_SetupFullScreenExclusive();
+	if (vid_fullscreen->value && vk_config.vk_ext_full_screen_exclusive_available)
+	{
+		surfaceCaps = Vkimp_SetupFullScreenExclusive();
+	}
 #endif
 
 	VK_VERIFY(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk_device.physical, vk_surface, &surfaceCaps));

--- a/ref_vk/vk_swapchain.c
+++ b/ref_vk/vk_swapchain.c
@@ -120,6 +120,11 @@ VkResult QVk_CreateSwapchain()
 	VkSurfaceFormatKHR *surfaceFormats = NULL;
 	VkPresentModeKHR *presentModes = NULL;
 	uint32_t formatCount, presentModesCount;
+
+#ifdef FS_EXCLUSIVE
+	surfaceCaps = Vkimp_SetupFullScreenExclusive();
+#endif
+
 	VK_VERIFY(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk_device.physical, vk_surface, &surfaceCaps));
 	VK_VERIFY(vkGetPhysicalDeviceSurfaceFormatsKHR(vk_device.physical, vk_surface, &formatCount, NULL));
 	VK_VERIFY(vkGetPhysicalDeviceSurfacePresentModesKHR(vk_device.physical, vk_surface, &presentModesCount, NULL));
@@ -194,6 +199,13 @@ VkResult QVk_CreateSwapchain()
 		.clipped = VK_TRUE,
 		.oldSwapchain = oldSwapchain
 	};
+
+#ifdef FS_EXCLUSIVE
+	if (vk_config.vk_full_screen_exclusive_supported)
+	{
+		scCreateInfo.pNext = &vk_state.full_screen_exclusive_info;
+	}
+#endif
 
 	uint32_t queueFamilyIndices[] = { (uint32_t)vk_device.gfxFamilyIndex, (uint32_t)vk_device.presentFamilyIndex };
 	if (vk_device.presentFamilyIndex != vk_device.gfxFamilyIndex)

--- a/ref_vk/vk_swapchain.c
+++ b/ref_vk/vk_swapchain.c
@@ -204,7 +204,7 @@ VkResult QVk_CreateSwapchain()
 	};
 
 #ifdef FULL_SCREEN_EXCLUSIVE_ENABLED
-	if (vk_config.vk_full_screen_exclusive_supported)
+	if (vk_config.vk_full_screen_exclusive_enabled)
 	{
 		scCreateInfo.pNext = &vk_state.full_screen_exclusive_info;
 	}
@@ -224,6 +224,18 @@ VkResult QVk_CreateSwapchain()
 	ri.Con_Printf(PRINT_ALL, "...trying swapchain image format: %d\n", vk_swapchain.format);
 
 	VkResult res = vkCreateSwapchainKHR(vk_device.logical, &scCreateInfo, NULL, &vk_swapchain.sc);
+	// "In some cases, swapchain creation may fail if exclusive full - screen mode is requested for application control, 
+	// but for some implementation - specific reason exclusive full - screen access is unavailable for the particular combination
+	// of parameters provided. If this occurs, VK_ERROR_INITIALIZATION_FAILED will be returned."
+	//
+	// This seems to affect at least a certain AMD Vega + Intel combination when running on a TV, so disable fullscreen exclusive and try again.
+	if (vk_config.vk_full_screen_exclusive_enabled && res == VK_ERROR_INITIALIZATION_FAILED)
+	{
+		ri.Con_Printf(PRINT_ALL, "...received VK_ERROR_INITIALIZATION_FAILED from vkCreateSwapchainKHR() - disabling fullscreen exclusive!\n");
+		scCreateInfo.pNext = NULL;
+		res = vkCreateSwapchainKHR(vk_device.logical, &scCreateInfo, NULL, &vk_swapchain.sc);
+		vk_config.vk_full_screen_exclusive_enabled = false;
+	}
 	if (res != VK_SUCCESS)
 		return res;
 

--- a/win32/vk_imp.c
+++ b/win32/vk_imp.c
@@ -211,7 +211,7 @@ VkSurfaceCapabilitiesKHR Vkimp_SetupFullScreenExclusive()
 
 	PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR qvkGetPhysicalDeviceSurfaceCapabilities2KHR = (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vkGetInstanceProcAddr(vk_instance, "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
 	VK_VERIFY(qvkGetPhysicalDeviceSurfaceCapabilities2KHR(vk_device.physical, &surfInfo2, &surfCap2));
-	vk_config.vk_full_screen_exclusive_supported = surfCapFse.fullScreenExclusiveSupported;
+	vk_config.vk_full_screen_exclusive_enabled = surfCapFse.fullScreenExclusiveSupported;
 	return surfCap2.surfaceCapabilities;
 }
 

--- a/win32/vk_imp.c
+++ b/win32/vk_imp.c
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "winquake.h"
 
 vkwstate_t vkw_state;
+VkSurfaceFullScreenExclusiveWin32InfoEXT g_surface_full_screen_exclusive_win32_info;
 
 extern cvar_t *vid_fullscreen;
 extern cvar_t *vid_ref;
@@ -112,7 +113,8 @@ qboolean VID_CreateWindow( int width, int height, qboolean fullscreen )
 
 	memset( &vkw_state.monInfo, 0, sizeof(MONITORINFOEX) );
 	vkw_state.monInfo.cbSize = sizeof(MONITORINFOEX);
-	GetMonitorInfo( MonitorFromWindow(vkw_state.hWnd, MONITOR_DEFAULTTOPRIMARY), (LPMONITORINFO)&vkw_state.monInfo );
+	vkw_state.monitor = MonitorFromWindow(vkw_state.hWnd, MONITOR_DEFAULTTOPRIMARY);
+	GetMonitorInfo( vkw_state.monitor, (LPMONITORINFO)&vkw_state.monInfo );
 
 	if (fullscreen)
 	{
@@ -135,7 +137,8 @@ qboolean VID_CreateWindow( int width, int height, qboolean fullscreen )
 			return false;
 		}
 
-		GetMonitorInfo( MonitorFromWindow(vkw_state.hWnd, MONITOR_DEFAULTTOPRIMARY), (LPMONITORINFO)&vkw_state.monInfo );
+		vkw_state.monitor = MonitorFromWindow(vkw_state.hWnd, MONITOR_DEFAULTTOPRIMARY);
+		GetMonitorInfo( vkw_state.monitor, (LPMONITORINFO)&vkw_state.monInfo );
 		SetWindowPos( vkw_state.hWnd, NULL, vkw_state.monInfo.rcMonitor.left, vkw_state.monInfo.rcMonitor.top, width, height,
 			SWP_NOACTIVATE | SWP_NOCOPYBITS | SWP_NOOWNERZORDER | SWP_NOREPOSITION | SWP_NOZORDER );
 	}
@@ -161,10 +164,11 @@ void Vkimp_GetSurfaceExtensions(char **extensions, uint32_t *extCount)
 	{
 		extensions[0] = VK_KHR_SURFACE_EXTENSION_NAME;
 		extensions[1] = VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
+		extensions[2] = VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME;
 	}
 
 	if (extCount)
-		*extCount = 2;
+		*extCount = 3;
 }
 
 VkResult Vkimp_CreateSurface()
@@ -178,6 +182,37 @@ VkResult Vkimp_CreateSurface()
 	};
 
 	return vkCreateWin32SurfaceKHR(vk_instance, &surfaceCreateInfo, NULL, &vk_surface);
+}
+
+VkSurfaceCapabilitiesKHR Vkimp_SetupFullScreenExclusive()
+{
+	g_surface_full_screen_exclusive_win32_info.sType = VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT;
+	g_surface_full_screen_exclusive_win32_info.pNext = NULL;
+	g_surface_full_screen_exclusive_win32_info.hmonitor = vkw_state.monitor;
+
+	vk_state.full_screen_exclusive_info.sType = VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT;
+	vk_state.full_screen_exclusive_info.pNext = &g_surface_full_screen_exclusive_win32_info;
+	vk_state.full_screen_exclusive_info.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT;
+
+	VkPhysicalDeviceSurfaceInfo2KHR surfInfo2 = {
+		.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR,
+		.pNext = &vk_state.full_screen_exclusive_info,
+		.surface = vk_surface
+	};
+	VkSurfaceCapabilitiesFullScreenExclusiveEXT surfCapFse = {
+		.sType = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT,
+		.pNext = NULL,
+		.fullScreenExclusiveSupported = VK_FALSE
+	};
+	VkSurfaceCapabilities2KHR surfCap2 = {
+		.sType = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR,
+		.pNext = &surfCapFse
+	};
+
+	PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR qvkGetPhysicalDeviceSurfaceCapabilities2KHR = (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vkGetInstanceProcAddr(vk_instance, "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+	VK_VERIFY(qvkGetPhysicalDeviceSurfaceCapabilities2KHR(vk_device.physical, &surfInfo2, &surfCap2));
+	vk_config.vk_full_screen_exclusive_supported = surfCapFse.fullScreenExclusiveSupported;
+	return surfCap2.surfaceCapabilities;
 }
 
 /*

--- a/win32/vk_win.h
+++ b/win32/vk_win.h
@@ -30,6 +30,7 @@ typedef struct
 	HINSTANCE	hInstance;
 	void	*wndproc;
 	HWND    hWnd;			// handle to window
+	HMONITOR monitor;		// active monitor
 	MONITORINFOEX monInfo;	// active monitor info
 
 	qboolean allowdisplaydepthchange;


### PR DESCRIPTION
Added exclusive fullscreen support on Windows and removed VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT flag in favor of resetting entire command pools manually for performance boost.