### PR TITLE
Don't require fillModeNonSolid device feature

### DIFF
--- a/ref_vk/vk_device.c
+++ b/ref_vk/vk_device.c
@@ -75,7 +75,11 @@ static void getBestPhysicalDevice(const VkPhysicalDevice *devices, int preferred
 			qboolean extSupported = deviceExtensionsSupported(&devices[i]);
 
 			// no required extensions? try next device
-			if (!extSupported || !deviceFeatures.samplerAnisotropy || !deviceFeatures.fillModeNonSolid)
+			if (!extSupported)
+				continue;
+
+			// no required deviceFeature? try next device
+			if (!deviceFeatures.samplerAnisotropy)
 				continue;
 
 			// if extensions are fine, query surface formats and present modes to see if the device can be used


### PR DESCRIPTION
Not all drivers support it. Also, just checking the code, only
VK_POLYGON_MODE_FILL is used, so asking for it doesn't seem really
needed.