### PR TITLE
linux/Makefile: fixed superfluous optimization level

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -69,7 +69,7 @@ ifeq ($(ARCH),axp)
 RELEASE_CFLAGS=$(BASE_CFLAGS) -DNDEBUG -O6 -ffast-math -funroll-loops \
 	-fomit-frame-pointer -fexpensive-optimizations
 else
-RELEASE_CFLAGS=$(BASE_CFLAGS) -DNDEBUG -O6 -ffast-math -funroll-loops \
+RELEASE_CFLAGS=$(BASE_CFLAGS) -DNDEBUG -O3 -ffast-math -funroll-loops \
 	-fomit-frame-pointer -fexpensive-optimizations
 endif
 


### PR DESCRIPTION
GCC allows this optimization level (-O6), although it actually sets -O3, but another compilers (e.g. EDG) does not.