### PR TITLE
E2K: added initial support of MCST Elbrus 2000 CPU architecture

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -29,6 +29,9 @@ else ifeq ($(KERNEL_ARCH),ppc64le)
 else ifeq ($(KERNEL_ARCH),armv7l)
   ARCH=armv7l
   RPMARCH=armv7l
+else ifeq ($(KERNEL_ARCH),e2k)
+  ARCH=e2k
+  RPMARCH=e2k
 else ifneq (,$(findstring alpha,$(KERNEL_ARCH)))
   ARCH=axp
   RPMARCH=alpha
@@ -68,6 +71,8 @@ BASE_CFLAGS=-I/usr/local/include -Dstricmp=strcasecmp -D_GNU_SOURCE -Wno-format-
 ifeq ($(ARCH),axp)
 RELEASE_CFLAGS=$(BASE_CFLAGS) -DNDEBUG -O3 -ffast-math -funroll-loops \
 	-fomit-frame-pointer -fexpensive-optimizations
+else ifeq ($(ARCH),e2k)
+RELEASE_CFLAGS=$(BASE_CFLAGS) -DNDEBUG -O3 -ffast-math -ffast
 else
 RELEASE_CFLAGS=$(BASE_CFLAGS) -DNDEBUG -O3 -ffast-math -funroll-loops \
 	-fomit-frame-pointer -fexpensive-optimizations

--- a/linux/sys_linux.c
+++ b/linux/sys_linux.c
@@ -230,7 +230,9 @@ void *Sys_GetGameAPI (void *parms)
 #elif defined __powerpc64__
 	const char *gamename = "gameppc64.so";
 #elif defined __arm__
-        const char *gamename = "gamearmv7l.so";
+	const char *gamename = "gamearmv7l.so";
+#elif defined __e2k__
+	const char *gamename = "gamee2k.so";
 #else
 #error Unknown arch
 #endif


### PR DESCRIPTION
E2K (Elbrus 2000) - this is VLIW/EPIC architecture, like Intel Itanium (IA-64) architecture.

Ref: https://en.wikipedia.org/wiki/Elbrus_2000