### PR TITLE
Use XInitThreads to fix vulkan driver issues

### DIFF
--- a/linux/vk_imp.c
+++ b/linux/vk_imp.c
@@ -635,6 +635,7 @@ int Vkimp_SetMode( int *pwidth, int *pheight, int mode, qboolean fullscreen )
 	else
 		putenv("MESA_GLX_FX=window");
 
+	XInitThreads();
 	if (!(dpy = XOpenDisplay(NULL))) {
 		fprintf(stderr, "Error couldn't open the X display\n");
 		return rserr_invalid_mode;


### PR DESCRIPTION
Hey and thanks for your work! 

Under certain circumstances in linux, I am getting crashes (on master):
```
[xcb] Unknown sequence number while processing queue
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
xcb_io.c:260: poll_for_event: Assertion `!xcb_xlib_threads_sequence_lost' failed.
```

It seems there is a data race that is very rarely triggered with normal usage.
I looked a bit around and it seems that the mesa vulkan drivers require
XInitThreads to be called (they are indeed creating WSI threads internally), see 
[here](https://github.com/Try/OpenGothic/issues/16), also [vkcube](https://github.com/googlesamples/vulkan-basic-samples/blob/master/demos/cube.c#L2607) does it without using threads itself.

EDIT: nevermind, the [spec itself](https://www.khronos.org/registry/vulkan/specs/1.1-khr-extensions/html/chap31.html#platformCreateSurface_xlib) states this must be done, search for XInitThreads in that chapter.

Adding this to the code fixes the issue for me.
