### PR TITLE
Update colorbuffer and colorbufferWarp samplers in QVk_RecreateSwapchain

### DIFF
--- a/ref_vk/vk_common.c
+++ b/ref_vk/vk_common.c
@@ -2192,6 +2192,8 @@ void QVk_RecreateSwapchain()
 	vk_scissor.extent = vk_swapchain.extent;
 	DestroyDrawBuffers();
 	CreateDrawBuffers();
+	QVk_UpdateTextureSampler(&vk_colorbuffer, S_NEAREST);
+	QVk_UpdateTextureSampler(&vk_colorbufferWarp, S_NEAREST);
 	VK_VERIFY(CreateImageViews());
 	VK_VERIFY(CreateFramebuffers());
 }


### PR DESCRIPTION
I'm aware this is dead code that's no longer used, but in case somebody digs it up and decides to use it again for some reason, I'm hoping this will save them some hours of pain and suffering.