### PR TITLE
Fix wrong team announce on flag return

### DIFF
--- a/ctf/g_misc.c
+++ b/ctf/g_misc.c
@@ -319,7 +319,7 @@ void BecomeExplosion1 (edict_t *self)
 	if (strcmp(self->classname, "item_flag_team2") == 0) {
 		CTFResetFlag(CTF_TEAM2); // this will free self!
 		gi.bprintf(PRINT_HIGH, "The %s flag has returned!\n",
-			CTFTeamName(CTF_TEAM1));
+			CTFTeamName(CTF_TEAM2));
 		return;
 	}
 	// techs are important too


### PR DESCRIPTION
Fix wrong team being announced when the blue flag is returned after it gets destroyed.

Before:
```
[PDL]TOMMYROT got the BLUE flag!
[PDL]TOMMYROT was in the wrong place.
[PDL]TOMMYROT lost the BLUE flag!
The RED flag has returned!
```

After:
```
[PDL]TOMMYROT got the BLUE flag!
[PDL]TOMMYROT was in the wrong place.
[PDL]TOMMYROT lost the BLUE flag!
The BLUE flag has returned!
```