### PR TITLE
Changes to support MoltenVK.

### DIFF
--- a/macos/Makefile
+++ b/macos/Makefile
@@ -8,8 +8,8 @@ RELEASE_CFLAGS=$(BASE_CFLAGS) -DNDEBUG -O3
 DEBUG_CFLAGS=$(BASE_CFLAGS) -g -D_DEBUG
 LDFLAGS=-framework CoreAudio
 
-VKLDFLAGS=-L$(VULKAN_SDK)/macOS/lib -Xlinker -rpath -Xlinker $(VULKAN_SDK)/macOS/lib -lvulkan -lstdc++ -framework Cocoa -framework QuartzCore
-VKCFLAGS=-I$(VULKAN_SDK)/macOS/include
+VKLDFLAGS=-L$(VULKAN_SDK)/lib -Xlinker -rpath -Xlinker $(VULKAN_SDK)/lib -lvulkan -lstdc++ -framework Cocoa -framework QuartzCore
+VKCFLAGS=-I$(VULKAN_SDK)/include
 
 SHLIBCFLAGS=-fPIC -std=c99
 SHLIBCPPFLAGS=-fPIC -std=c++11

--- a/macos/vk_imp.m
+++ b/macos/vk_imp.m
@@ -293,6 +293,7 @@ void Vkimp_GetInstanceExtensions(char **extensions, uint32_t *extCount)
 {
 	// check if we can use optional instance extensions
 	uint32_t instanceExtCount;
+	uint32_t extCountTemp;
 	VK_VERIFY(vkEnumerateInstanceExtensionProperties(NULL, &instanceExtCount, NULL));
 
 	if (instanceExtCount > 0)
@@ -303,6 +304,7 @@ void Vkimp_GetInstanceExtensions(char **extensions, uint32_t *extCount)
 		for (int i = 0; i < instanceExtCount; ++i)
 		{
 			vk_config.vk_khr_get_physical_device_properties2_available |= strcmp(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, availableExtensions[i].extensionName) == 0;
+			vk_config.vk_khr_portability_enumeration_available |= strcmp(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, availableExtensions[i].extensionName) == 0;
 #if DEBUG_UTILS_AVAILABLE
 			vk_config.vk_ext_debug_utils_supported |= strcmp(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, availableExtensions[i].extensionName) == 0;
 #endif
@@ -318,13 +320,29 @@ void Vkimp_GetInstanceExtensions(char **extensions, uint32_t *extCount)
 	{
 		extensions[0] = VK_KHR_SURFACE_EXTENSION_NAME;
 		extensions[1] = VK_MVK_MACOS_SURFACE_EXTENSION_NAME;
+		extCountTemp = 2;
+		// required for MoltenVK when using Vulkan loader.
 		// required by VK_EXT_full_screen_exclusive and VK_KHR_portability_subset
 		if (vk_config.vk_khr_get_physical_device_properties2_available)
-			extensions[2] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
+		{
+			extensions[extCountTemp] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
+			extCountTemp++;
+		}
+		if (vk_config.vk_khr_portability_enumeration_available)
+		{
+			extensions[extCountTemp] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+			extCountTemp++;
+		}
+
 	}
 
 	if (extCount)
-		*extCount = vk_config.vk_khr_get_physical_device_properties2_available ? 3 : 2;
+	{
+		*extCount = 2;
+		*extCount += vk_config.vk_khr_get_physical_device_properties2_available;
+		*extCount += vk_config.vk_khr_portability_enumeration_available;
+	}
+
 }
 
 VkResult Vkimp_CreateSurface()

--- a/ref_vk/vk_common.c
+++ b/ref_vk/vk_common.c
@@ -1573,6 +1573,7 @@ qboolean QVk_Init()
 
 	uint32_t extCount;
 	char **wantedExtensions;
+	VkInstanceCreateFlags flags;
 	memset((char*)vk_config.supported_present_modes, 0, 256);
 	memset((char*)vk_config.extensions, 0, 256);
 	memset((char*)vk_config.layers, 0, 256);
@@ -1595,6 +1596,7 @@ qboolean QVk_Init()
 	vk_config.sampler_descriptor_set_count = 0;
 	vk_config.swapchain_image_count = 0;
 	vk_config.vk_khr_portability_subset_available = false;
+	vk_config.vk_khr_portability_enumeration_available = false;
 	vk_config.vk_khr_get_physical_device_properties2_available = false;
 	vk_config.vk_khr_get_surface_capabilities2_available = false;
 	vk_config.vk_ext_debug_utils_supported = false;
@@ -1618,6 +1620,10 @@ qboolean QVk_Init()
 
 	wantedExtensions = (char **)malloc(extCount * sizeof(const char *));
 	Vkimp_GetInstanceExtensions(wantedExtensions, NULL);
+
+	flags = 0;
+	if (vk_config.vk_khr_portability_enumeration_available)
+		flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 
 #if DEBUG_UTILS_AVAILABLE
 	if (vk_config.vk_ext_debug_utils_supported)
@@ -1666,6 +1672,7 @@ qboolean QVk_Init()
 	VkInstanceCreateInfo createInfo = {
 		.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
 		.pNext = NULL,
+		.flags = flags,
 		.pApplicationInfo = &appInfo,
 		.enabledLayerCount = 0,
 		.ppEnabledLayerNames = NULL,

--- a/ref_vk/vk_local.h
+++ b/ref_vk/vk_local.h
@@ -327,6 +327,7 @@ typedef struct
 	uint32_t    sampler_descriptor_set_count;
 	int         swapchain_image_count;
 	qboolean    vk_khr_portability_subset_available;  // this extension must be enabled according to the specs if the device supports it
+	qboolean    vk_khr_portability_enumeration_available; // required by MoltenVK
 	qboolean    vk_khr_get_physical_device_properties2_available; // required by VK_KHR_portability_subset and VK_EXT_full_screen_exclusive
 	qboolean    vk_khr_get_surface_capabilities2_available; // required by VK_EXT_full_screen_exclusive
 	qboolean    vk_ext_debug_utils_supported;
@@ -394,7 +395,7 @@ void		Vkimp_BeginFrame( float camera_separation );
 void		Vkimp_EndFrame( void );
 int 		Vkimp_Init( void *hinstance, void *hWnd );
 void		Vkimp_Shutdown( void );
-int			Vkimp_SetMode( int *pwidth, int *pheight, int mode, qboolean fullscreen );
+int		Vkimp_SetMode( int *pwidth, int *pheight, int mode, qboolean fullscreen );
 void		Vkimp_AppActivate( qboolean active );
 void		Vkimp_EnableLogging( qboolean enable );
 void		Vkimp_LogNewFrame( void );


### PR DESCRIPTION
The tidied up changes suggested in #150 where extension updates required MoltenVK to be enabled as an allowed device using new extensions and flags - see: [MoltenVK Runtime UserGuide](https://github.com/KhronosGroup/MoltenVK/blob/8692a9df52adb6a74b159506b317af7abb8bbdce/Docs/MoltenVK_Runtime_UserGuide.md) 

Had to fix Makefile also since `VULKAN_SDK` should include `macOS` directory e.g. from https://vulkan.lunarg.com/doc/sdk/1.3.224.1/mac/getting_started.html