### PR TITLE
Fix stack execution flag in linux assembly code

### DIFF
--- a/linux/snd_mixa.s
+++ b/linux/snd_mixa.s
@@ -191,3 +191,6 @@ LClampDone2:
 
 #endif	// id386
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
I noticed that the Linux quake2 executable was flagged as having an executable stack.
Since an executable stack could in theory be used for stack smashing some especially hardened systems will outright disallow the usage of code having an executable stack.
Anyway the gnu assembler (used by GCC) can and will not automatically flag code as assembly is rather low level.

After testing the created object files of a release build I could assess that only `linux/snd_mixa.s` was causing issues.
Further testing proved that the flag being set has to be after the id386l `#endif`

For more information you can read the Gentoo article on this subject:
https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart