### PR TITLE
Fix missing cstdio include in ref_vk/vk_mem_alloc.h

### DIFF
--- a/ref_vk/vk_mem_alloc.h
+++ b/ref_vk/vk_mem_alloc.h
@@ -2565,6 +2565,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
 #ifdef VMA_IMPLEMENTATION
 #undef VMA_IMPLEMENTATION
 
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
vk_ref/vk_mem_alloc.cpp/h causes compilation errors with GCC due to usage of `snprintf` without  `#include <cstdio>`
